### PR TITLE
generated code for task 5

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,8 @@
 # STATE.md — Session Entry Point
 
 **Last updated:** 2026-03-26
-**Active task:** TASK-005
-**Branch:** cursor-pagination
+**Active task:** TASK-006
+**Branch:** health-check-endpoints
 
 ---
 
@@ -26,7 +26,7 @@
 | 002 | [Base ORM patterns, enums, Alembic config](tasks/TASK-002-base-orm-patterns.md) | **Complete** | 001 |
 | 003 | [Error response contract & exception handling](tasks/TASK-003-error-response-contract.md) | **Complete** | 001 |
 | 004 | [Cursor pagination utility](tasks/TASK-004-cursor-pagination.md) | **Complete** | 001, 003 |
-| 005 | [Health check endpoints](tasks/TASK-005-health-check-endpoints.md) | Partial | 001 |
+| 005 | [Health check endpoints](tasks/TASK-005-health-check-endpoints.md) | **Complete** | 001 |
 | 006 | [AuditLog model & audit service](tasks/TASK-006-audit-log-model-and-service.md) | Partial | 001, 002 |
 | 007 | [Structured logging & PHI exclusion filter](tasks/TASK-007-structured-logging-phi-filter.md) | Partial | 001 |
 | 008 | [Test infrastructure & fixtures](tasks/TASK-008-test-infrastructure.md) | Partial | 001, 002, 003, 007 |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.core.exceptions import GroundworkError
 from app.core.lifespan import lifespan
 from app.core.logger import get_logger
 from app.core.settings import settings
+from app.routers import health as health_router
 
 logger = get_logger(__name__)
 
@@ -142,10 +143,8 @@ def create_app() -> FastAPI:
             },
         )
 
-    # Health check (no auth required)
-    @app.get("/api/v1/health", tags=["health"])
-    async def health_check():
-        return {"status": "healthy", "version": settings.app_version}
+    # Health endpoints — public, no auth (SPEC-007 §9)
+    app.include_router(health_router.router, prefix="/api/v1")
 
     # TODO: Phase 1 - Include EAV routers
     # TODO: Phase 2 - Include Identity/RBAC routers

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,0 +1,73 @@
+"""
+Health check endpoints (SPEC-007 §9).
+
+GET /health        — liveness probe (process is running)
+GET /health/ready  — readiness probe (DB is reachable)
+
+Neither endpoint requires authentication or X-Organization-Id.
+The `_check_database` dependency is injectable so tests can override it
+without mocking internals.
+
+TASK-014 adds `auth0_jwks` to the readiness checks dict when auth
+middleware is wired up.
+"""
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from app.core.database import Database
+from app.core.settings import settings
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+# ---------------------------------------------------------------------------
+# Dependencies — overridable in tests
+# ---------------------------------------------------------------------------
+
+async def _check_database() -> str:
+    """Probe the database with SELECT 1.  Returns 'ok' or 'error'."""
+    try:
+        from sqlalchemy import text
+
+        engine = Database.get_engine()
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return "ok"
+    except Exception:
+        return "error"
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("")
+async def liveness() -> dict:
+    """Liveness probe — returns 200 if the process is running."""
+    return {"status": "ok", "version": settings.app_version}
+
+
+@router.get("/ready")
+async def readiness(
+    database: str = Depends(_check_database),
+) -> JSONResponse:
+    """Readiness probe — returns 200 when all dependencies are healthy.
+
+    Returns 503 if any check fails.  The ``checks`` dict is intentionally
+    open-ended: TASK-014 adds ``auth0_jwks`` without changing this envelope.
+    """
+    checks: dict[str, str] = {
+        "database": database,
+        # auth0_jwks: added by TASK-014
+    }
+
+    all_ok = all(v == "ok" for v in checks.values())
+
+    return JSONResponse(
+        status_code=200 if all_ok else 503,
+        content={
+            "status": "ready" if all_ok else "unhealthy",
+            "checks": checks,
+        },
+    )

--- a/backend/tests/test_cross_cutting/test_health.py
+++ b/backend/tests/test_cross_cutting/test_health.py
@@ -1,16 +1,103 @@
-"""Smoke test for the health check endpoint."""
+"""
+Tests for health check endpoints (SPEC-007 §9).
+
+GET /api/v1/health        — liveness (always 200)
+GET /api/v1/health/ready  — readiness (200 when DB ok, 503 when DB unreachable)
+"""
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+from app.routers.health import _check_database
+
+
+# ---------------------------------------------------------------------------
+# Liveness  —  GET /api/v1/health
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_liveness_returns_200(client: AsyncClient):
+    response = await client.get("/api/v1/health")
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_health_check_returns_200(client: AsyncClient):
-    """GET /api/v1/health should return 200 with status and version."""
-    response = await client.get("/api/v1/health")
+async def test_liveness_status_is_ok(client: AsyncClient):
+    data = (await client.get("/api/v1/health")).json()
+    assert data["status"] == "ok"
 
+
+@pytest.mark.asyncio
+async def test_liveness_includes_version(client: AsyncClient):
+    data = (await client.get("/api/v1/health")).json()
+    assert "version" in data
+    assert data["version"]
+
+
+# ---------------------------------------------------------------------------
+# Readiness (happy path)  —  GET /api/v1/health/ready
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_readiness_returns_200_when_db_ok(client: AsyncClient):
+    response = await client.get("/api/v1/health/ready")
     assert response.status_code == 200
 
-    data = response.json()
-    assert data["status"] == "healthy"
-    assert "version" in data
+
+@pytest.mark.asyncio
+async def test_readiness_status_is_ready_when_db_ok(client: AsyncClient):
+    data = (await client.get("/api/v1/health/ready")).json()
+    assert data["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_readiness_checks_dict_contains_database_ok(client: AsyncClient):
+    data = (await client.get("/api/v1/health/ready")).json()
+    assert "checks" in data
+    assert data["checks"]["database"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Readiness (DB-degraded path)  —  503
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_readiness_returns_503_when_db_unreachable():
+    """Override the DB check dependency to simulate an unreachable database."""
+    app = create_app()
+    app.dependency_overrides[_check_database] = lambda: "error"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as degraded_client:
+        response = await degraded_client.get("/api/v1/health/ready")
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_readiness_status_is_unhealthy_when_db_unreachable():
+    app = create_app()
+    app.dependency_overrides[_check_database] = lambda: "error"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as degraded_client:
+        data = (await degraded_client.get("/api/v1/health/ready")).json()
+
+    assert data["status"] == "unhealthy"
+    assert data["checks"]["database"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_readiness_checks_dict_extensible_for_task_014():
+    """The checks dict must accommodate the future auth0_jwks key (TASK-014)."""
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        data = (await c.get("/api/v1/health/ready")).json()
+
+    assert isinstance(data["checks"], dict)

--- a/task-logs/TASK-005-log.md
+++ b/task-logs/TASK-005-log.md
@@ -1,0 +1,32 @@
+# TASK-005 Log — Health Check Endpoints
+
+**Agent:** cursor
+**Branch:** health-check-endpoints
+**Date completed:** 2026-03-26
+
+## What Was Done
+
+### `backend/app/routers/health.py` — new file
+- `GET /health` (liveness): returns `{"status": "ok", "version": "..."}`.
+- `GET /health/ready` (readiness): runs `SELECT 1` against the DB engine and returns `{"status": "ready"/"unhealthy", "checks": {"database": "ok"/"error"}}` with HTTP 200/503.
+- The `checks` dict is intentionally open-ended — TASK-014 adds `auth0_jwks` without changing the envelope shape.
+- DB check extracted into a standalone async dependency `_check_database` so tests can override it with `app.dependency_overrides` without needing mocks.
+
+### `backend/app/main.py`
+- Removed the inline `GET /api/v1/health` route returning `"healthy"`.
+- Imported `health_router` and registered it at `/api/v1` prefix.
+
+### `backend/tests/test_cross_cutting/test_health.py` — rewritten
+- 9 tests: liveness 200 / `status == "ok"` / version present; readiness 200 / `"ready"` / `checks.database == "ok"`; DB-degraded 503 / `"unhealthy"` / `checks.database == "error"`; checks-dict extensibility assertion.
+
+## Decisions Made
+
+- **Injectable `_check_database` dependency:** The DB probe is a named FastAPI dependency overridable via `app.dependency_overrides`. This avoids patching `Database.get_engine` with `unittest.mock`, which would violate the no-mocks convention. Overriding a FastAPI dependency is idiomatic and tests the handler logic directly.
+
+## Deviations from Task
+
+None. All acceptance criteria implemented.
+
+## Open Items
+
+TASK-014 will add `auth0_jwks` to the `checks` dict and its corresponding dependency.

--- a/tasks/TASK-005-health-check-endpoints.md
+++ b/tasks/TASK-005-health-check-endpoints.md
@@ -1,6 +1,6 @@
 # TASK-005: Health Check Endpoints
 
-**Status:** Partial
+**Status:** Complete
 **Spec sections:** SPEC-007 §9, §8.8
 **ADRs:** —
 **Depends on:** TASK-001
@@ -11,16 +11,12 @@ Implement the two health check endpoints: `/api/v1/health` (liveness) and `/api/
 
 ## Acceptance Criteria
 
-- [ ] `GET /api/v1/health` returns 200 `{"status": "ok", "version": "1.0.0"}` with no auth required — endpoint exists inline in `main.py` but currently returns `{"status": "healthy", ...}`; rename to `"ok"` per spec and move to `app/routers/health.py`
-- [ ] `GET /api/v1/health/ready` returns 200 `{"status": "ready", "checks": {"database": "ok"}}` when DB is reachable
-- [ ] `GET /api/v1/health/ready` returns 503 `{"status": "unhealthy", "checks": {...}}` when DB is unreachable
-- [ ] `checks` dict is structured to allow TASK-014 to add an `auth0_jwks` key without changing the envelope
+- [x] `GET /api/v1/health` returns 200 `{"status": "ok", "version": "..."}` — extracted to `app/routers/health.py`, registered via `include_router`
+- [x] `GET /api/v1/health/ready` returns 200 `{"status": "ready", "checks": {"database": "ok"}}` when DB is reachable
+- [x] `GET /api/v1/health/ready` returns 503 `{"status": "unhealthy", "checks": {...}}` when DB is unreachable
+- [x] `checks` dict is structured to allow TASK-014 to add an `auth0_jwks` key without changing the envelope
 - [x] Both endpoints are excluded from auth middleware (no auth middleware yet — implicitly satisfied until TASK-014)
-- [ ] Tests verify both happy path and DB-degraded states
-
-**Done so far (in code):** `GET /api/v1/health` inline in `main.py` returning `{"status": "healthy", "version": ...}`; basic health test exists.
-
-**Remaining:** rename `"healthy"` → `"ok"`; extract to `app/routers/health.py`; implement `/health/ready` with DB ping; add 503 on DB failure; add tests for DB-degraded state. Keep endpoints exempt from auth middleware when TASK-014 lands.
+- [x] Tests verify both happy path and DB-degraded states — 9 tests
 
 ## Files
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds public health endpoints and tests with a simple `SELECT 1` DB probe; primary risk is misreporting readiness if DB engine initialization/config is wrong.
> 
> **Overview**
> Adds a dedicated `health` router and registers it under `/api/v1`, replacing the previous inline `/health` handler and aligning the liveness response to `{"status":"ok","version":...}`.
> 
> Introduces `GET /api/v1/health/ready` readiness checks that probe database connectivity and return **200/503** with an extensible `checks` map, and rewrites health tests to cover liveness, readiness, and DB-degraded behavior via FastAPI dependency overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2387fd6f232f2c13841696bf37e4fc8fb749a73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->