### PR TITLE
TASK-008C: configure ruff + strict mypy

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,8 @@
 # STATE.md — Session Entry Point
 
-**Last updated:** 2026-03-26
-**Active task:** TASK-007
-**Branch:** audit-log-service
+**Last updated:** 2026-04-29
+**Active task:** TASK-007 (next on phase1-finish branch)
+**Branch:** phase1-finish
 
 ---
 
@@ -32,7 +32,7 @@
 | 008 | [Test infrastructure & fixtures](tasks/TASK-008-test-infrastructure.md) | Partial | 001, 002, 003, 007 |
 | 008A | [Service & router layer conventions (shared plumbing only)](tasks/TASK-008A-service-router-conventions.md) | Partial | 002, 003, 004, 006, 007, 008 |
 | 008B | [CI pipeline configuration (GitHub Actions: lint, type check, tests, build)](tasks/TASK-008B-ci-pipeline.md) | Not started | 001, 002, 007, 008, 008C |
-| 008C | [Linter & type-check configuration (ruff + mypy strict in pyproject.toml)](tasks/TASK-008C-linter-config.md) | Not started | 001 |
+| 008C | [Linter & type-check configuration (ruff + mypy strict in pyproject.toml)](tasks/TASK-008C-linter-config.md) | **Complete** | 001 |
 
 **Partial status notes:**
 - **003:** 7 exception classes exist (`GroundworkError`, `NotFoundError`, `ValidationError`, `ConflictError`, `ForbiddenError`, `OrganizationRequiredError`, `BridgeRuleViolation`, `StatusTransitionError`) + `ErrorResponse` schema + handler in `main.py`. Missing: `ResourceLockedError`, `PrerequisiteNotMetError`, `AccountInactiveError`, `UnauthorizedError`, `BadRequestError`, `OrgAccessDeniedError`, `RateLimitedError`, `InternalError`; Pydantic 422 handler; generic 500 handler. Error code `status_transition_error` should be `state_transition_denied` per SPEC-007.

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -13,11 +13,16 @@ import uuid
 from datetime import datetime
 from threading import Lock
 
-from sqlalchemy import DateTime, MetaData, String, text
+from sqlalchemy import DateTime, MetaData, text
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncAttrs,
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy.ext.asyncio import AsyncAttrs
 
 from app.core.logger import get_logger
 
@@ -121,19 +126,15 @@ class Database:
         """Return the session factory, raising if not yet initialized."""
         with cls._lock:
             if cls._session_factory is None:
-                raise RuntimeError(
-                    "Database not initialized. Call Database.initialize() first."
-                )
+                raise RuntimeError("Database not initialized. Call Database.initialize() first.")
             return cls._session_factory
 
     @classmethod
-    def get_engine(cls):
+    def get_engine(cls) -> AsyncEngine:
         """Return the async engine, raising if not yet initialized."""
         with cls._lock:
             if cls._engine is None:
-                raise RuntimeError(
-                    "Database not initialized. Call Database.initialize() first."
-                )
+                raise RuntimeError("Database not initialized. Call Database.initialize() first.")
             return cls._engine
 
     @classmethod

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -27,4 +27,4 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
             raise
 
 
-__all__ = ["get_db", "get_auth_context", "require_permission"]
+__all__ = ["get_auth_context", "get_db", "require_permission"]

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -34,6 +34,7 @@ class GroundworkError(Exception):
 # 400
 # ---------------------------------------------------------------------------
 
+
 class BadRequestError(GroundworkError):
     def __init__(self, message: str, details: list[dict[str, Any]] | None = None):
         super().__init__(
@@ -45,7 +46,7 @@ class BadRequestError(GroundworkError):
 
 
 class OrganizationRequiredError(GroundworkError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             error="organization_required",
             message="An organization context is required for this operation.",
@@ -57,6 +58,7 @@ class OrganizationRequiredError(GroundworkError):
 # 401
 # ---------------------------------------------------------------------------
 
+
 class UnauthorizedError(GroundworkError):
     def __init__(self, message: str = "Authentication is required."):
         super().__init__(
@@ -67,7 +69,7 @@ class UnauthorizedError(GroundworkError):
 
 
 class AccountInactiveError(GroundworkError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             error="account_inactive",
             message="This account is inactive or has been deleted.",
@@ -79,6 +81,7 @@ class AccountInactiveError(GroundworkError):
 # 403
 # ---------------------------------------------------------------------------
 
+
 class ForbiddenError(GroundworkError):
     def __init__(self, message: str = "You do not have permission to perform this action."):
         super().__init__(
@@ -89,7 +92,7 @@ class ForbiddenError(GroundworkError):
 
 
 class OrgAccessDeniedError(GroundworkError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             error="org_access_denied",
             message="You do not have an active role in the requested organization.",
@@ -100,6 +103,7 @@ class OrgAccessDeniedError(GroundworkError):
 # ---------------------------------------------------------------------------
 # 404
 # ---------------------------------------------------------------------------
+
 
 class NotFoundError(GroundworkError):
     def __init__(self, resource: str, resource_id: UUID):
@@ -119,6 +123,7 @@ class NotFoundError(GroundworkError):
 # 409
 # ---------------------------------------------------------------------------
 
+
 class ConflictError(GroundworkError):
     def __init__(self, message: str, details: list[dict[str, Any]] | None = None):
         super().__init__(
@@ -135,11 +140,13 @@ class StateTransitionDeniedError(GroundworkError):
             error="state_transition_denied",
             message=f"Cannot transition {resource} from '{current_status}' to '{target_status}'.",
             status_code=409,
-            details=[{
-                "resource": resource,
-                "current_status": current_status,
-                "target_status": target_status,
-            }],
+            details=[
+                {
+                    "resource": resource,
+                    "current_status": current_status,
+                    "target_status": target_status,
+                }
+            ],
         )
 
 
@@ -156,6 +163,7 @@ class ResourceLockedError(GroundworkError):
 # ---------------------------------------------------------------------------
 # 422
 # ---------------------------------------------------------------------------
+
 
 class DomainValidationError(GroundworkError):
     """Business-rule validation failure (distinct from Pydantic schema errors)."""
@@ -178,11 +186,13 @@ class BridgeRuleViolation(GroundworkError):
                 f"expected entity type '{expected_type}', got '{actual_type}'."
             ),
             status_code=422,
-            details=[{
-                "field": field,
-                "expected_type": expected_type,
-                "actual_type": actual_type,
-            }],
+            details=[
+                {
+                    "field": field,
+                    "expected_type": expected_type,
+                    "actual_type": actual_type,
+                }
+            ],
         )
 
 
@@ -200,8 +210,9 @@ class PrerequisiteNotMetError(GroundworkError):
 # 429
 # ---------------------------------------------------------------------------
 
+
 class RateLimitedError(GroundworkError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             error="rate_limited",
             message="Too many requests. Please try again later.",
@@ -213,8 +224,9 @@ class RateLimitedError(GroundworkError):
 # 500
 # ---------------------------------------------------------------------------
 
+
 class InternalError(GroundworkError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             error="internal_error",
             message="An unexpected error occurred.",

--- a/backend/app/core/logger.py
+++ b/backend/app/core/logger.py
@@ -11,13 +11,12 @@ centralized exclusion list shared with the audit service).
 import logging
 
 import structlog
+from structlog.types import EventDict, WrappedLogger
 
 from app.core.phi import PHI_EXCLUDED_FIELDS
 
 
-def phi_filter(
-    logger: logging.Logger, method_name: str, event_dict: dict
-) -> dict:
+def phi_filter(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
     """Structlog processor that strips PHI fields from log events."""
     for field in PHI_EXCLUDED_FIELDS:
         event_dict.pop(field, None)
@@ -26,11 +25,7 @@ def phi_filter(
 
 def setup_logging(log_level: str = "INFO", log_json: bool = True) -> None:
     """Configure structlog with JSON or console rendering."""
-    renderer = (
-        structlog.processors.JSONRenderer()
-        if log_json
-        else structlog.dev.ConsoleRenderer()
-    )
+    renderer = structlog.processors.JSONRenderer() if log_json else structlog.dev.ConsoleRenderer()
 
     structlog.configure(
         processors=[
@@ -59,4 +54,5 @@ def setup_logging(log_level: str = "INFO", log_json: bool = True) -> None:
 
 def get_logger(name: str) -> structlog.stdlib.BoundLogger:
     """Return a bound structlog logger for the given module name."""
-    return structlog.get_logger(name)
+    logger: structlog.stdlib.BoundLogger = structlog.get_logger(name)
+    return logger

--- a/backend/app/core/phi.py
+++ b/backend/app/core/phi.py
@@ -19,33 +19,34 @@ audit row that cannot be amended after the fact.
 
 from __future__ import annotations
 
-
-PHI_EXCLUDED_FIELDS: frozenset[str] = frozenset({
-    # Clinical-note format keys (SPEC-006 §4 BR-08)
-    "subjective",
-    "objective",
-    "assessment",
-    "plan",
-    "data",
-    "intervention",
-    "response",
-    "behavior",
-    # ClinicalNote container — the entire content JSONB carries PHI
-    "content",
-    "note_content",
-    # Person demographics
-    "date_of_birth",
-    "dob",
-    "ssn",
-    "social_security",
-    "emergency_contact_name",
-    "emergency_contact_phone",
-    # EAV — SPEC-001 §7 explicitly requires AttributeValue value exclusion
-    "value",
-    # ClientConsent / Document free-text
-    "notes",
-    "description",
-    # Billing — diagnosis codes correlated to a specific client
-    "diagnosis_codes",
-    "icd_codes",
-})
+PHI_EXCLUDED_FIELDS: frozenset[str] = frozenset(
+    {
+        # Clinical-note format keys (SPEC-006 §4 BR-08)
+        "subjective",
+        "objective",
+        "assessment",
+        "plan",
+        "data",
+        "intervention",
+        "response",
+        "behavior",
+        # ClinicalNote container — the entire content JSONB carries PHI
+        "content",
+        "note_content",
+        # Person demographics
+        "date_of_birth",
+        "dob",
+        "ssn",
+        "social_security",
+        "emergency_contact_name",
+        "emergency_contact_phone",
+        # EAV — SPEC-001 §7 explicitly requires AttributeValue value exclusion
+        "value",
+        # ClientConsent / Document free-text
+        "notes",
+        "description",
+        # Billing — diagnosis codes correlated to a specific client
+        "diagnosis_codes",
+        "icd_codes",
+    }
+)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -6,9 +6,11 @@ with real Auth0 JWT validation via auth0-fastapi-api.
 """
 
 from dataclasses import dataclass, field
+from typing import cast
 from uuid import UUID
 
 from fastapi import Depends, HTTPException
+from fastapi.params import Depends as DependsParam
 
 
 @dataclass
@@ -33,7 +35,7 @@ async def get_auth_context() -> AuthContext:
     )
 
 
-def require_permission(permission_slug: str):
+def require_permission(permission_slug: str) -> DependsParam:
     """Dependency factory that checks whether the authenticated user has a specific permission.
 
     Usage:
@@ -50,4 +52,4 @@ def require_permission(permission_slug: str):
             )
         return auth
 
-    return Depends(_check_permission)
+    return cast(DependsParam, Depends(_check_permission))

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -24,7 +24,9 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://groundwork:groundwork@db:5432/groundwork"
 
     # Test database
-    test_database_url: str = "postgresql+asyncpg://groundwork:groundwork@db-test:5432/groundwork_test"
+    test_database_url: str = (
+        "postgresql+asyncpg://groundwork:groundwork@db-test:5432/groundwork_test"
+    )
 
     # Auth0
     auth0_domain: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,9 +60,7 @@ def create_app() -> FastAPI:
 
     # Domain errors — GroundworkError subclasses (SPEC-007 §7.3)
     @app.exception_handler(GroundworkError)
-    async def groundwork_error_handler(
-        request: Request, exc: GroundworkError
-    ) -> JSONResponse:
+    async def groundwork_error_handler(request: Request, exc: GroundworkError) -> JSONResponse:
         return JSONResponse(
             status_code=exc.status_code,
             content={
@@ -89,11 +87,13 @@ def create_app() -> FastAPI:
                     continue
                 field_parts.append(str(part))
             # Never echo the submitted value — `input` may contain PHI (SPEC-007 §7.4).
-            details.append({
-                "field": ".".join(field_parts) if field_parts else "body",
-                "message": error.get("msg", "Invalid value."),
-                "code": error.get("type", "value_error"),
-            })
+            details.append(
+                {
+                    "field": ".".join(field_parts) if field_parts else "body",
+                    "message": error.get("msg", "Invalid value."),
+                    "code": error.get("type", "value_error"),
+                }
+            )
         return JSONResponse(
             status_code=422,
             content={
@@ -107,9 +107,7 @@ def create_app() -> FastAPI:
     # HTTPException (unknown route 404, 405, hand-raised HTTPException) must also
     # return the canonical envelope (SPEC-007 §7.1 / TASK-003 objective).
     @app.exception_handler(StarletteHTTPException)
-    async def http_exception_handler(
-        request: Request, exc: StarletteHTTPException
-    ) -> JSONResponse:
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
         error_code = _HTTP_STATUS_TO_ERROR_CODE.get(exc.status_code, "http_error")
         message = exc.detail if isinstance(exc.detail, str) else "HTTP error."
         return JSONResponse(
@@ -126,9 +124,7 @@ def create_app() -> FastAPI:
     # Catch-all — never leak internals (SPEC-007 §7.3 internal_error).
     # Uses structlog so the project's PHI filter runs before emission.
     @app.exception_handler(Exception)
-    async def unhandled_exception_handler(
-        request: Request, exc: Exception
-    ) -> JSONResponse:
+    async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
         logger.exception(
             "unhandled_exception",
             method=request.method,

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -22,7 +22,6 @@ from sqlalchemy import (
     Boolean,
     Date,
     DateTime,
-    Enum as SAEnum,
     ForeignKey,
     Index,
     Integer,
@@ -31,15 +30,18 @@ from sqlalchemy import (
     UniqueConstraint,
     text,
 )
+from sqlalchemy import (
+    Enum as SAEnum,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base, IdMixin, SoftDeleteMixin, TimestampMixin
 
-
 # ---------------------------------------------------------------------------
 # Enums — one StrEnum per domain, defined before the model that uses it
 # ---------------------------------------------------------------------------
+
 
 # EAV
 class FieldType(StrEnum):
@@ -136,6 +138,7 @@ class FormType(StrEnum):
 # EAV Domain  (SPEC-001)
 # ---------------------------------------------------------------------------
 
+
 class Organization(Base, IdMixin, TimestampMixin):
     __tablename__ = "organizations"
 
@@ -182,9 +185,7 @@ class EntityAttribute(Base, IdMixin, TimestampMixin):
     field_type: Mapped[FieldType] = mapped_column(
         SAEnum(FieldType, native_enum=False), nullable=False
     )
-    is_required: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("false")
-    )
+    is_required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
     # Can be a list (enum options) or a string (FK target slug) — stored as JSONB
     options: Mapped[Any] = mapped_column(JSONB, nullable=True)
     display_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
@@ -203,9 +204,7 @@ class EntityInstance(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     person_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("people.id"), nullable=True
     )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class AttributeValue(Base, IdMixin):
@@ -215,9 +214,7 @@ class AttributeValue(Base, IdMixin):
     """
 
     __tablename__ = "attribute_values"
-    __table_args__ = (
-        UniqueConstraint("entity_instance_id", "entity_attribute_id"),
-    )
+    __table_args__ = (UniqueConstraint("entity_instance_id", "entity_attribute_id"),)
 
     entity_instance_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("entity_instances.id"), nullable=False
@@ -232,6 +229,7 @@ class AttributeValue(Base, IdMixin):
 # ---------------------------------------------------------------------------
 # Identity Domain  (SPEC-002)
 # ---------------------------------------------------------------------------
+
 
 class Person(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     """
@@ -249,16 +247,12 @@ class Person(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     phone: Mapped[str | None] = mapped_column(String, nullable=True)
     # PHI — excluded from AuditLog snapshots per BR-08
     date_of_birth: Mapped[date | None] = mapped_column(Date, nullable=True)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class Role(Base, IdMixin, TimestampMixin):
     __tablename__ = "roles"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "slug"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "slug"),)
 
     # NULL = system role (globally reserved slug)
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -281,9 +275,7 @@ class Role(Base, IdMixin, TimestampMixin):
 
 class Permission(Base, IdMixin, TimestampMixin):
     __tablename__ = "permissions"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "slug"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "slug"),)
 
     # NULL = system permission (globally reserved slug)
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -310,7 +302,10 @@ class PersonRole(Base, IdMixin, TimestampMixin):
         # A person cannot hold duplicate active copies of the same scoped role
         Index(
             "uq_person_roles_active",
-            "organization_id", "person_id", "role_id", "entity_instance_id",
+            "organization_id",
+            "person_id",
+            "role_id",
+            "entity_instance_id",
             unique=True,
             postgresql_where=text("revoked_at IS NULL"),
         ),
@@ -349,7 +344,9 @@ class RolePermission(Base, IdMixin, TimestampMixin):
     __table_args__ = (
         Index(
             "uq_role_permissions_active",
-            "organization_id", "role_id", "permission_id",
+            "organization_id",
+            "role_id",
+            "permission_id",
             unique=True,
             postgresql_where=text("revoked_at IS NULL"),
         ),
@@ -379,6 +376,7 @@ class RolePermission(Base, IdMixin, TimestampMixin):
 # Scheduling Domain  (SPEC-003)
 # ---------------------------------------------------------------------------
 
+
 class AppointmentType(Base, IdMixin, TimestampMixin):
     __tablename__ = "appointment_types"
 
@@ -393,12 +391,8 @@ class AppointmentType(Base, IdMixin, TimestampMixin):
     is_telehealth: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
-    is_intake: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("false")
-    )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_intake: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class Session(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
@@ -438,6 +432,7 @@ class Session(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
 # ---------------------------------------------------------------------------
 # Clinical Domain  (SPEC-004)
 # ---------------------------------------------------------------------------
+
 
 class ClinicalNote(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "clinical_notes"
@@ -487,11 +482,10 @@ class ClinicalNote(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
 # Billing Domain  (SPEC-005)
 # ---------------------------------------------------------------------------
 
+
 class CPTCode(Base, IdMixin, TimestampMixin):
     __tablename__ = "cpt_codes"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "code"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "code"),)
 
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
@@ -499,25 +493,19 @@ class CPTCode(Base, IdMixin, TimestampMixin):
     code: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=False)
     default_rate_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class ICDCode(Base, IdMixin, TimestampMixin):
     __tablename__ = "icd_codes"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "code"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "code"),)
 
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
     )
     code: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=False)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class InsurancePayer(Base, IdMixin, TimestampMixin):
@@ -530,9 +518,7 @@ class InsurancePayer(Base, IdMixin, TimestampMixin):
     payer_id: Mapped[str | None] = mapped_column(String, nullable=True)
     phone: Mapped[str | None] = mapped_column(String, nullable=True)
     address: Mapped[str | None] = mapped_column(Text, nullable=True)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class ClientInsurance(Base, IdMixin, TimestampMixin):
@@ -541,7 +527,10 @@ class ClientInsurance(Base, IdMixin, TimestampMixin):
         # A client cannot have two active records of the same priority with the same payer
         Index(
             "uq_client_insurances_active_priority",
-            "organization_id", "client_instance_id", "insurance_payer_id", "priority",
+            "organization_id",
+            "client_instance_id",
+            "insurance_payer_id",
+            "priority",
             unique=True,
             postgresql_where=text("is_active = true"),
         ),
@@ -568,9 +557,7 @@ class ClientInsurance(Base, IdMixin, TimestampMixin):
     deductible_met_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
     effective_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     termination_date: Mapped[date | None] = mapped_column(Date, nullable=True)
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class Invoice(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
@@ -607,7 +594,9 @@ class Invoice(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     due_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     # Computed and stored atomically at write time — never computed on the fly
     total_cents: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
-    amount_paid_cents: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    amount_paid_cents: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
     balance_cents: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     voided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -683,6 +672,7 @@ class Payment(Base, IdMixin, TimestampMixin):
 # Compliance Domain  (SPEC-006)
 # ---------------------------------------------------------------------------
 
+
 class AuditLog(Base, IdMixin):
     """
     IdMixin only — SPEC-006 §2 explicitly forbids updated_at and deleted_at.
@@ -715,9 +705,7 @@ class AuditLog(Base, IdMixin):
 
 class DocumentType(Base, IdMixin, TimestampMixin):
     __tablename__ = "document_types"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "slug"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "slug"),)
 
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
@@ -729,9 +717,7 @@ class DocumentType(Base, IdMixin, TimestampMixin):
     is_system_type: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class Document(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
@@ -748,25 +734,19 @@ class Document(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     uploaded_by_person_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("people.id"), nullable=False
     )
-    linked_resource_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), nullable=True
-    )
+    linked_resource_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     file_name: Mapped[str] = mapped_column(String(255), nullable=False)
     mime_type: Mapped[str] = mapped_column(String, nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
     # Never exposed in API responses — used only for presigned URL generation
     s3_key: Mapped[str] = mapped_column(String, nullable=False)
     s3_bucket: Mapped[str] = mapped_column(String, nullable=False)
-    is_encrypted: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_encrypted: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class ConsentType(Base, IdMixin, TimestampMixin):
     __tablename__ = "consent_types"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "slug"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "slug"),)
 
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
@@ -776,9 +756,7 @@ class ConsentType(Base, IdMixin, TimestampMixin):
     is_system_type: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
 
 
 class ClientConsent(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
@@ -820,26 +798,18 @@ class ClientConsent(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
 
 class FormTemplate(Base, IdMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "form_templates"
-    __table_args__ = (
-        UniqueConstraint("organization_id", "slug"),
-    )
+    __table_args__ = (UniqueConstraint("organization_id", "slug"),)
 
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
     slug: Mapped[str] = mapped_column(String, nullable=False)
-    form_type: Mapped[FormType] = mapped_column(
-        SAEnum(FormType, native_enum=False), nullable=False
-    )
+    form_type: Mapped[FormType] = mapped_column(SAEnum(FormType, native_enum=False), nullable=False)
     # Python attr is schema_ to avoid collision with SQLAlchemy's .schema property
-    schema_: Mapped[dict[str, Any]] = mapped_column(
-        JSONB, name="schema", nullable=False
-    )
+    schema_: Mapped[dict[str, Any]] = mapped_column(JSONB, name="schema", nullable=False)
     version: Mapped[str] = mapped_column(String, nullable=False, server_default="1.0.0")
     is_system_template: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default=text("true")
-    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))

--- a/backend/app/routers/compliance.py
+++ b/backend/app/routers/compliance.py
@@ -8,7 +8,6 @@ Both endpoints require the ``audit.read`` permission (enforced once TASK-014
 and TASK-015 wire up auth middleware and permission resolution).
 """
 
-import uuid
 from datetime import datetime
 from typing import Any
 from uuid import UUID
@@ -35,6 +34,7 @@ _SORT_FIELDS = {
 # Response schema (inline — full Pydantic schemas come in TASK-008A)
 # ---------------------------------------------------------------------------
 
+
 def _serialize(entry: AuditLog) -> dict[str, Any]:
     return {
         "id": str(entry.id),
@@ -54,6 +54,7 @@ def _serialize(entry: AuditLog) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
+
 
 @router.get(
     "",

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -26,10 +26,10 @@ router = APIRouter(prefix="/health", tags=["health"])
 # Dependencies — overridable in tests
 # ---------------------------------------------------------------------------
 
+
 async def _check_database() -> str:
     """Probe the database with SELECT 1.  Returns 'ok' or 'error'."""
     try:
-
         engine = Database.get_engine()
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
@@ -42,8 +42,9 @@ async def _check_database() -> str:
 # Endpoints
 # ---------------------------------------------------------------------------
 
+
 @router.get("")
-async def liveness() -> dict:
+async def liveness() -> dict[str, str]:
     """Liveness probe — returns 200 if the process is running."""
     return {"status": "ok", "version": settings.app_version}
 

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -53,7 +53,10 @@ class PaginationParams(BaseModel):
 
     limit: int = Field(default=25, ge=1, le=100, description="Items per page. Maximum 100.")
     cursor: str | None = Field(default=None, description="Opaque cursor from a previous response.")
-    sort: str = Field(default="created_at", description="Column to sort by. Must be an indexed field.")
+    sort: str = Field(
+        default="created_at",
+        description="Column to sort by. Must be an indexed field.",
+    )
     sort_dir: SortDir = Field(default=SortDir.DESC, description="Sort direction: asc or desc.")
 
 

--- a/backend/app/services/audit_service.py
+++ b/backend/app/services/audit_service.py
@@ -12,7 +12,7 @@ is the single platform-wide source of truth.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -20,7 +20,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.phi import PHI_EXCLUDED_FIELDS
 from app.models.models import AuditLog
-
 
 __all__ = ["PHI_EXCLUDED_FIELDS", "filter_phi", "log_action"]
 
@@ -40,10 +39,9 @@ def filter_phi(
     if snapshot is None:
         return None
     if isinstance(snapshot, list):
-        return [filter_phi(item) if isinstance(item, (dict, list)) else item
-                for item in snapshot]
+        return [filter_phi(item) if isinstance(item, dict | list) else item for item in snapshot]
     return {
-        k: (filter_phi(v) if isinstance(v, (dict, list)) else v)
+        k: (filter_phi(v) if isinstance(v, dict | list) else v)
         for k, v in snapshot.items()
         if k not in PHI_EXCLUDED_FIELDS
     }
@@ -52,6 +50,7 @@ def filter_phi(
 # ---------------------------------------------------------------------------
 # Core audit function
 # ---------------------------------------------------------------------------
+
 
 async def log_action(
     db: AsyncSession,
@@ -110,7 +109,7 @@ async def log_action(
         next_state=filter_phi(next_state),
         ip_address=ip_address,
         user_agent=user_agent,
-        occurred_at=datetime.now(tz=timezone.utc),
+        occurred_at=datetime.now(tz=UTC),
     )
     db.add(entry)
     return entry

--- a/backend/app/utils/pagination.py
+++ b/backend/app/utils/pagination.py
@@ -53,6 +53,7 @@ T = TypeVar("T")
 # Cursor encode / decode
 # ---------------------------------------------------------------------------
 
+
 def encode_cursor(sort_value: Any, record_id: UUID | str) -> str:
     """Encode a keyset cursor as a URL-safe Base64 JSON string.
 
@@ -60,7 +61,7 @@ def encode_cursor(sort_value: Any, record_id: UUID | str) -> str:
     Datetime and date values are stored as ISO 8601 strings.
     The format is opaque to API clients and may change between versions.
     """
-    if isinstance(sort_value, (datetime, date)):
+    if isinstance(sort_value, datetime | date):
         v = sort_value.isoformat()
     elif isinstance(sort_value, UUID):
         v = str(sort_value)
@@ -68,9 +69,7 @@ def encode_cursor(sort_value: Any, record_id: UUID | str) -> str:
         v = sort_value
 
     payload = {"v": v, "id": str(record_id)}
-    return base64.urlsafe_b64encode(
-        json.dumps(payload, separators=(",", ":")).encode()
-    ).decode()
+    return base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
 
 
 def decode_cursor(cursor: str) -> dict[str, Any]:
@@ -82,22 +81,23 @@ def decode_cursor(cursor: str) -> dict[str, Any]:
     try:
         # Add padding in case the encoded string lost trailing '='
         padded = cursor + "==" * (4 - len(cursor) % 4)
-        data = json.loads(base64.urlsafe_b64decode(padded))
+        data: dict[str, Any] = json.loads(base64.urlsafe_b64decode(padded))
         if "v" not in data or "id" not in data:
             raise ValueError("missing required cursor keys")
         return data
-    except Exception:
-        raise BadRequestError("Invalid or expired pagination cursor.")
+    except Exception as exc:
+        raise BadRequestError("Invalid or expired pagination cursor.") from exc
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-def _coerce_cursor_value(raw: Any, sort_col: InstrumentedAttribute) -> Any:
+
+def _coerce_cursor_value(raw: Any, sort_col: InstrumentedAttribute[Any]) -> Any:
     """Convert a raw JSON cursor value to the Python type that SQLAlchemy expects."""
     try:
-        col_type = sort_col.property.columns[0].type  # type: ignore[attr-defined]
+        col_type = sort_col.property.columns[0].type
         if isinstance(col_type, DateTime) and isinstance(raw, str):
             return datetime.fromisoformat(raw)
         if isinstance(col_type, Date) and isinstance(raw, str):
@@ -111,13 +111,14 @@ def _coerce_cursor_value(raw: Any, sort_col: InstrumentedAttribute) -> Any:
 # Core pagination function
 # ---------------------------------------------------------------------------
 
+
 async def paginate(
     session: AsyncSession,
-    stmt: Select,
+    stmt: Select[Any],
     *,
     params: PaginationParams,
-    sort_fields: dict[str, InstrumentedAttribute],
-    id_col: InstrumentedAttribute,
+    sort_fields: dict[str, InstrumentedAttribute[Any]],
+    id_col: InstrumentedAttribute[Any],
 ) -> tuple[list[Any], PaginationMeta]:
     """Apply cursor conditions, ordering, and limit to a SQLAlchemy SELECT.
 
@@ -150,8 +151,7 @@ async def paginate(
     """
     if params.sort not in sort_fields:
         raise BadRequestError(
-            f"Cannot sort by '{params.sort}'. "
-            f"Allowed fields: {sorted(sort_fields)}."
+            f"Cannot sort by '{params.sort}'. " f"Allowed fields: {sorted(sort_fields)}."
         )
 
     sort_col = sort_fields[params.sort]
@@ -166,14 +166,12 @@ async def paginate(
         if params.sort_dir == SortDir.DESC:
             # Rows before the cursor in descending order
             stmt = stmt.where(
-                (sort_col < cursor_v)
-                | ((sort_col == cursor_v) & (id_col < cursor_id))
+                (sort_col < cursor_v) | ((sort_col == cursor_v) & (id_col < cursor_id))
             )
         else:
             # Rows after the cursor in ascending order
             stmt = stmt.where(
-                (sort_col > cursor_v)
-                | ((sort_col == cursor_v) & (id_col > cursor_id))
+                (sort_col > cursor_v) | ((sort_col == cursor_v) & (id_col > cursor_id))
             )
 
     # Stable ordering: (sort_col, id) ensures no ambiguity on ties
@@ -214,9 +212,10 @@ async def paginate(
 # Filter helpers  (SPEC-007 §6.1)
 # ---------------------------------------------------------------------------
 
+
 def apply_exact_filter(
-    stmt: Select, col: InstrumentedAttribute, value: Any
-) -> Select:
+    stmt: Select[Any], col: InstrumentedAttribute[Any], value: Any
+) -> Select[Any]:
     """WHERE col = value.  No-op when value is None."""
     if value is not None:
         return stmt.where(col == value)
@@ -224,8 +223,8 @@ def apply_exact_filter(
 
 
 def apply_in_filter(
-    stmt: Select, col: InstrumentedAttribute, value: str | None
-) -> Select:
+    stmt: Select[Any], col: InstrumentedAttribute[Any], value: str | None
+) -> Select[Any]:
     """WHERE col IN (...) parsed from a comma-separated query param.
 
     Example: ``?status=DRAFT,SENT`` → ``WHERE status IN ('DRAFT', 'SENT')``
@@ -239,11 +238,11 @@ def apply_in_filter(
 
 
 def apply_date_range_filter(
-    stmt: Select,
-    col: InstrumentedAttribute,
+    stmt: Select[Any],
+    col: InstrumentedAttribute[Any],
     date_from: date | datetime | None,
     date_to: date | datetime | None,
-) -> Select:
+) -> Select[Any]:
     """WHERE col >= date_from AND col <= date_to.
 
     Each bound is optional.  Both bounds are inclusive.
@@ -256,8 +255,8 @@ def apply_date_range_filter(
 
 
 def apply_text_search(
-    stmt: Select, col: InstrumentedAttribute, q: str | None
-) -> Select:
+    stmt: Select[Any], col: InstrumentedAttribute[Any], q: str | None
+) -> Select[Any]:
     """WHERE col ILIKE '%q%'.  No-op when q is None or empty."""
     if q:
         return stmt.where(col.ilike(f"%{q}%"))

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,6 +29,54 @@ factory-boy = "^3.3.0"
 coverage = "^7.0.0"
 pytest-cov = "^6.0.0"
 
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+extend-exclude = ["alembic/versions"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF"]
+ignore = [
+    "B008",   # FastAPI relies on Depends(...) defaults in signatures
+    "SIM117", # nested `with` blocks are clearer than combined ones in our async test code
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "S101",   # asserts are the point of tests
+    "B011",   # assert False is a valid sentinel in tests
+    "RUF001", # ambiguous unicode in fixture data is fine
+]
+"alembic/**" = [
+    "E501",   # auto-generated revisions can have long lines
+    "F401",   # imported-but-unused alembic helpers in env.py / templates
+    "I001",   # auto-generated import order
+    "UP",     # don't rewrite generated migrations
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"
+docstring-code-format = false
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+plugins = ["pydantic.mypy"]
+exclude = ["alembic/versions/"]
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_decorators = false
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = ["factory.*", "factory_boy.*"]
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/backend/tests/test_compliance/test_audit_log.py
+++ b/backend/tests/test_compliance/test_audit_log.py
@@ -16,14 +16,13 @@ A module-scoped fixture installs it against the test DB if not already present.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select, text, update
 from sqlalchemy.exc import DBAPIError
-from sqlalchemy.ext.asyncio import AsyncSession, AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.core.security import AuthContext, get_auth_context
 from app.main import create_app
@@ -31,13 +30,13 @@ from app.models.models import AuditLog, Organization
 from app.services import audit_service
 from app.services.audit_service import PHI_EXCLUDED_FIELDS, filter_phi
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _utc(year: int, month: int, day: int) -> datetime:
-    return datetime(year, month, day, tzinfo=timezone.utc)
+    return datetime(year, month, day, tzinfo=UTC)
 
 
 async def _make_org(session: AsyncSession, name: str = "Test Org") -> Organization:
@@ -57,6 +56,7 @@ async def _make_org(session: AsyncSession, name: str = "Test Org") -> Organizati
 # Module fixture: install immutability trigger on test DB
 # ---------------------------------------------------------------------------
 
+
 @pytest_asyncio.fixture(scope="module", loop_scope="session", autouse=True)
 async def install_immutability_trigger(test_engine: AsyncEngine):
     """Ensure the audit_log immutability triggers exist in the test DB.
@@ -67,7 +67,8 @@ async def install_immutability_trigger(test_engine: AsyncEngine):
     # asyncpg cannot execute multiple SQL commands in a single prepared
     # statement, so each DDL command must be issued separately.
     async with test_engine.begin() as conn:
-        await conn.execute(text("""
+        await conn.execute(
+            text("""
             CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
             RETURNS TRIGGER LANGUAGE plpgsql AS $$
             BEGIN
@@ -76,28 +77,30 @@ async def install_immutability_trigger(test_engine: AsyncEngine):
                     TG_OP;
             END;
             $$;
-        """))
-        await conn.execute(text(
-            "DROP TRIGGER IF EXISTS audit_log_immutable_update ON audit_logs"
-        ))
-        await conn.execute(text("""
+        """)
+        )
+        await conn.execute(text("DROP TRIGGER IF EXISTS audit_log_immutable_update ON audit_logs"))
+        await conn.execute(
+            text("""
             CREATE TRIGGER audit_log_immutable_update
             BEFORE UPDATE ON audit_logs
             FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation()
-        """))
-        await conn.execute(text(
-            "DROP TRIGGER IF EXISTS audit_log_immutable_delete ON audit_logs"
-        ))
-        await conn.execute(text("""
+        """)
+        )
+        await conn.execute(text("DROP TRIGGER IF EXISTS audit_log_immutable_delete ON audit_logs"))
+        await conn.execute(
+            text("""
             CREATE TRIGGER audit_log_immutable_delete
             BEFORE DELETE ON audit_logs
             FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation()
-        """))
+        """)
+        )
 
 
 # ---------------------------------------------------------------------------
 # Auth stub fixture for endpoint tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def audit_client(db_session: AsyncSession):
@@ -116,6 +119,7 @@ def audit_client(db_session: AsyncSession):
         yield db_session
 
     from app.core.dependencies import get_db
+
     app.dependency_overrides[get_db] = _override_db
 
     return app
@@ -124,6 +128,7 @@ def audit_client(db_session: AsyncSession):
 # ===========================================================================
 # SPEC-006 §9 named test cases
 # ===========================================================================
+
 
 @pytest.mark.asyncio
 async def test_state_change_writes_audit_entry(db_session: AsyncSession):
@@ -159,8 +164,11 @@ async def test_audit_failure_rolls_back_business_operation(db_session: AsyncSess
     # Simulate a service: domain write + audit write in same session
     target_id = uuid.uuid4()
     new_org = Organization(
-        id=target_id, name="Should Disappear",
-        timezone="UTC", is_active=True, created_at=_utc(2026, 1, 2),
+        id=target_id,
+        name="Should Disappear",
+        timezone="UTC",
+        is_active=True,
+        created_at=_utc(2026, 1, 2),
     )
     db_session.add(new_org)
 
@@ -193,12 +201,12 @@ async def test_audit_snapshot_excludes_phi_fields(db_session: AsyncSession):
     phi_snapshot = {
         "id": str(uuid.uuid4()),
         "name": "Jane Doe",
-        "date_of_birth": "1990-01-01",   # PHI
-        "dob": "1990-01-01",             # PHI alias
+        "date_of_birth": "1990-01-01",  # PHI
+        "dob": "1990-01-01",  # PHI alias
         "content": {"subjective": "..."},  # PHI
-        "value": "some attribute value",   # PHI
+        "value": "some attribute value",  # PHI
         "notes": "sensitive clinical note",  # PHI
-        "ssn": "123-45-6789",             # PHI
+        "ssn": "123-45-6789",  # PHI
         # BR-08 clinical-note format keys at top level (not just under `content`):
         "subjective": "patient reports ...",
         "objective": "vitals normal ...",
@@ -208,7 +216,7 @@ async def test_audit_snapshot_excludes_phi_fields(db_session: AsyncSession):
         "intervention": "CBT exercise ...",
         "response": "client engaged ...",
         "behavior": "cooperative ...",
-        "status": "active",               # safe
+        "status": "active",  # safe
     }
     org = await _make_org(db_session)
     resource_id = uuid.uuid4()
@@ -259,9 +267,7 @@ async def test_update_audit_log_row_rejected(db_session: AsyncSession):
 
     with pytest.raises(DBAPIError, match="immutable"):
         await db_session.execute(
-            update(AuditLog)
-            .where(AuditLog.id == entry.id)
-            .values(action="tampered")
+            update(AuditLog).where(AuditLog.id == entry.id).values(action="tampered")
         )
         await db_session.flush()
 
@@ -283,9 +289,7 @@ async def test_delete_audit_log_row_rejected(db_session: AsyncSession):
     await db_session.flush()
 
     with pytest.raises(DBAPIError, match="immutable"):
-        await db_session.execute(
-            sa_delete(AuditLog).where(AuditLog.id == entry.id)
-        )
+        await db_session.execute(sa_delete(AuditLog).where(AuditLog.id == entry.id))
         await db_session.flush()
 
 
@@ -320,32 +324,43 @@ async def test_audit_log_filters_by_org(db_session: AsyncSession):
     resource_b = uuid.uuid4()
 
     await audit_service.log_action(
-        db_session, org_id=org_a.id, actor_id=None,
-        action="create", resource_type="Widget", resource_id=resource_a,
+        db_session,
+        org_id=org_a.id,
+        actor_id=None,
+        action="create",
+        resource_type="Widget",
+        resource_id=resource_a,
     )
     await audit_service.log_action(
-        db_session, org_id=org_b.id, actor_id=None,
-        action="create", resource_type="Widget", resource_id=resource_b,
+        db_session,
+        org_id=org_b.id,
+        actor_id=None,
+        action="create",
+        resource_type="Widget",
+        resource_id=resource_b,
     )
     await db_session.flush()
 
-    rows_a = (await db_session.execute(
-        select(AuditLog).where(AuditLog.organization_id == org_a.id)
-    )).scalars().all()
-    rows_b = (await db_session.execute(
-        select(AuditLog).where(AuditLog.organization_id == org_b.id)
-    )).scalars().all()
+    rows_a = (
+        (await db_session.execute(select(AuditLog).where(AuditLog.organization_id == org_a.id)))
+        .scalars()
+        .all()
+    )
+    rows_b = (
+        (await db_session.execute(select(AuditLog).where(AuditLog.organization_id == org_b.id)))
+        .scalars()
+        .all()
+    )
 
     assert all(r.organization_id == org_a.id for r in rows_a)
     assert all(r.organization_id == org_b.id for r in rows_b)
-    assert {r.resource_id for r in rows_a}.isdisjoint(
-        {r.resource_id for r in rows_b}
-    )
+    assert {r.resource_id for r in rows_a}.isdisjoint({r.resource_id for r in rows_b})
 
 
 # ===========================================================================
 # filter_phi() unit tests
 # ===========================================================================
+
 
 class TestFilterPhi:
     def test_none_input_returns_none(self):
@@ -416,6 +431,7 @@ class TestFilterPhi:
         }
         # Use copy to confirm non-mutation of nested structures too.
         import copy
+
         original = copy.deepcopy(snapshot)
         assert filter_phi(snapshot) == original
         assert snapshot == original
@@ -439,8 +455,8 @@ class TestPhiExclusionListCentralization:
 
     def test_audit_service_and_logger_share_the_same_constant(self):
         """audit_service.PHI_EXCLUDED_FIELDS must be the same object as logger's."""
-        from app.core.phi import PHI_EXCLUDED_FIELDS as canonical
         from app.core import logger as logger_module
+        from app.core.phi import PHI_EXCLUDED_FIELDS as canonical
         from app.services import audit_service as audit_module
 
         assert audit_module.PHI_EXCLUDED_FIELDS is canonical

--- a/backend/tests/test_cross_cutting/test_error_responses.py
+++ b/backend/tests/test_cross_cutting/test_error_responses.py
@@ -37,10 +37,10 @@ from app.core.exceptions import (
 )
 from app.main import create_app
 
-
 # ---------------------------------------------------------------------------
 # Test app fixture — one app with one trigger route per error code
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="module")
 def error_app() -> FastAPI:
@@ -92,7 +92,13 @@ def error_app() -> FastAPI:
     async def raise_domain_validation():
         raise DomainValidationError(
             "end_time must be after start_time.",
-            details=[{"field": "end_time", "message": "must be after start_time", "code": "invalid_time_range"}],
+            details=[
+                {
+                    "field": "end_time",
+                    "message": "must be after start_time",
+                    "code": "invalid_time_range",
+                }
+            ],
         )
 
     @app.get("/test/bridge-rule-violation")
@@ -176,6 +182,7 @@ async def ec(error_app: FastAPI):
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def assert_envelope(data: dict, error_code: str, status: int) -> None:
     assert data["error"] == error_code
     assert data["status"] == status
@@ -186,6 +193,7 @@ def assert_envelope(data: dict, error_code: str, status: int) -> None:
 # ---------------------------------------------------------------------------
 # 400
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_bad_request_returns_400(ec: AsyncClient):
@@ -205,6 +213,7 @@ async def test_organization_required_returns_400(ec: AsyncClient):
 # 401
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_unauthorized_returns_401(ec: AsyncClient):
     r = await ec.get("/test/unauthorized")
@@ -222,6 +231,7 @@ async def test_account_inactive_returns_401(ec: AsyncClient):
 # ---------------------------------------------------------------------------
 # 403
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_forbidden_returns_403(ec: AsyncClient):
@@ -241,6 +251,7 @@ async def test_org_access_denied_returns_403(ec: AsyncClient):
 # 404
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_not_found_returns_404(ec: AsyncClient):
     r = await ec.get("/test/not-found")
@@ -255,6 +266,7 @@ async def test_not_found_returns_404(ec: AsyncClient):
 # ---------------------------------------------------------------------------
 # 409
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_conflict_returns_409(ec: AsyncClient):
@@ -283,6 +295,7 @@ async def test_resource_locked_returns_409(ec: AsyncClient):
 # ---------------------------------------------------------------------------
 # 422
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_domain_validation_error_returns_422(ec: AsyncClient):
@@ -325,6 +338,7 @@ async def test_pydantic_validation_returns_422_with_field_details(ec: AsyncClien
 # 429
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_rate_limited_returns_429(ec: AsyncClient):
     r = await ec.get("/test/rate-limited")
@@ -335,6 +349,7 @@ async def test_rate_limited_returns_429(ec: AsyncClient):
 # ---------------------------------------------------------------------------
 # 500
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_internal_error_returns_500(ec: AsyncClient):
@@ -358,6 +373,7 @@ async def test_global_handler_returns_generic_500_without_internals(ec: AsyncCli
 # ---------------------------------------------------------------------------
 # HTTPException coercion (TASK-003 AC: validation, domain, HTTP, unhandled)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_unknown_route_returns_standard_envelope_404(ec: AsyncClient):
@@ -388,6 +404,7 @@ async def test_hand_raised_http_exception_uses_standard_envelope(ec: AsyncClient
 # ---------------------------------------------------------------------------
 # Validation loc handling (SPEC-007 §7.2 / §7.4)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_pydantic_validation_nested_field_path(ec: AsyncClient):
@@ -439,6 +456,6 @@ async def test_pydantic_validation_does_not_echo_submitted_value(ec: AsyncClient
     )
     assert r.status_code == 422
     body = r.text
-    assert phi_like_value not in body, (
-        "Submitted value leaked into response — SPEC-007 §7.4 PHI safety violation."
-    )
+    assert (
+        phi_like_value not in body
+    ), "Submitted value leaked into response — SPEC-007 §7.4 PHI safety violation."

--- a/backend/tests/test_cross_cutting/test_health.py
+++ b/backend/tests/test_cross_cutting/test_health.py
@@ -11,10 +11,10 @@ from httpx import ASGITransport, AsyncClient
 from app.main import create_app
 from app.routers.health import _check_database
 
-
 # ---------------------------------------------------------------------------
 # Liveness  —  GET /api/v1/health
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_liveness_returns_200(client: AsyncClient):
@@ -39,6 +39,7 @@ async def test_liveness_includes_version(client: AsyncClient):
 # Readiness (happy path)  —  GET /api/v1/health/ready
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_readiness_returns_200_when_db_ok(client: AsyncClient):
     response = await client.get("/api/v1/health/ready")
@@ -61,6 +62,7 @@ async def test_readiness_checks_dict_contains_database_ok(client: AsyncClient):
 # ---------------------------------------------------------------------------
 # Readiness (DB-degraded path)  —  503
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_readiness_returns_503_when_db_unreachable():
@@ -95,9 +97,7 @@ async def test_readiness_checks_dict_extensible_for_task_014():
     """The checks dict must accommodate the future auth0_jwks key (TASK-014)."""
     app = create_app()
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as c:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         data = (await c.get("/api/v1/health/ready")).json()
 
     assert isinstance(data["checks"], dict)

--- a/backend/tests/test_cross_cutting/test_pagination.py
+++ b/backend/tests/test_cross_cutting/test_pagination.py
@@ -12,10 +12,9 @@ Part 2 — Integration tests (real PostgreSQL via db_session fixture)
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
-import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,10 +31,10 @@ from app.utils.pagination import (
     paginate,
 )
 
-
 # ===========================================================================
 # Part 1 — Unit tests
 # ===========================================================================
+
 
 class TestEncodeDecode:
     def test_roundtrip_string_sort_value(self):
@@ -47,7 +46,7 @@ class TestEncodeDecode:
 
     def test_roundtrip_datetime_sort_value(self):
         record_id = uuid.uuid4()
-        ts = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+        ts = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
         cursor = encode_cursor(ts, record_id)
         data = decode_cursor(cursor)
         assert data["v"] == ts.isoformat()
@@ -71,7 +70,9 @@ class TestEncodeDecode:
             decode_cursor("!!!not-valid-base64!!!")
 
     def test_decode_valid_base64_missing_keys_raises_bad_request(self):
-        import base64, json
+        import base64
+        import json
+
         bad = base64.urlsafe_b64encode(json.dumps({"only": "one_key"}).encode()).decode()
         with pytest.raises(BadRequestError):
             decode_cursor(bad)
@@ -83,7 +84,7 @@ class TestEncodeDecode:
     def test_different_records_produce_different_cursors(self):
         id_a = uuid.uuid4()
         id_b = uuid.uuid4()
-        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
         assert encode_cursor(ts, id_a) != encode_cursor(ts, id_b)
 
 
@@ -97,11 +98,13 @@ class TestPaginationParams:
 
     def test_limit_max_is_100(self):
         from pydantic import ValidationError as PydanticValidationError
+
         with pytest.raises(PydanticValidationError):
             PaginationParams(limit=101)
 
     def test_limit_min_is_1(self):
         from pydantic import ValidationError as PydanticValidationError
+
         with pytest.raises(PydanticValidationError):
             PaginationParams(limit=0)
 
@@ -122,6 +125,7 @@ class TestPaginationParams:
 # Helper — insert N organizations with controlled created_at for ordering
 # ---------------------------------------------------------------------------
 
+
 async def _make_orgs(session: AsyncSession, count: int) -> list[Organization]:
     """Insert ``count`` organizations with known timestamps and return them newest-first."""
     orgs = []
@@ -131,7 +135,7 @@ async def _make_orgs(session: AsyncSession, count: int) -> list[Organization]:
             name=f"Org {i:02d}",
             timezone="UTC",
             is_active=True,
-            created_at=datetime(2026, 1, count - i, tzinfo=timezone.utc),
+            created_at=datetime(2026, 1, count - i, tzinfo=UTC),
         )
         session.add(org)
         orgs.append(org)
@@ -266,7 +270,7 @@ async def test_paginate_stable_after_insert(db_session: AsyncSession):
         timezone="UTC",
         is_active=True,
         # Older than all existing orgs, should appear at the end
-        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        created_at=datetime(2025, 1, 1, tzinfo=UTC),
     )
     db_session.add(late_org)
     await db_session.flush()
@@ -314,6 +318,7 @@ async def test_paginate_sort_ascending(db_session: AsyncSession):
 # Part 3 — Filter helper unit tests (no DB needed)
 # ===========================================================================
 
+
 class TestFilterHelpers:
     """Smoke tests for filter helpers — just verify they return Select objects."""
 
@@ -345,6 +350,7 @@ class TestFilterHelpers:
 
     def test_apply_date_range_filter_both_bounds(self):
         from datetime import date
+
         stmt = apply_date_range_filter(
             self._base_stmt(),
             Organization.created_at,

--- a/task-logs/TASK-008C-log.md
+++ b/task-logs/TASK-008C-log.md
@@ -1,0 +1,53 @@
+# TASK-008C Log — Linter & Type-Check Configuration
+
+**Agent:** claude-code
+**Branch:** phase1-finish
+**Date completed:** 2026-04-29
+
+## What Was Done
+
+Added `[tool.ruff]`, `[tool.ruff.lint]`, `[tool.ruff.lint.per-file-ignores]`, `[tool.ruff.format]`, `[tool.mypy]`, and `[[tool.mypy.overrides]]` sections to `backend/pyproject.toml`.
+
+- ruff rule selection: `E, F, W, I, B, UP, SIM, RUF`
+- ruff line-length: 100; target Python: 3.12; `alembic/versions` excluded
+- per-file-ignores: tests allow `S101`, `B011`, `RUF001`; alembic relaxes `E501`, `F401`, `I001`, `UP`
+- mypy: `strict = true`, `python_version = "3.12"`, pydantic plugin enabled, `alembic/versions/` excluded
+- mypy overrides: tests relax `disallow_untyped_defs` / `disallow_incomplete_defs` / `disallow_untyped_decorators`; `factory.*` / `factory_boy.*` get `ignore_missing_imports`
+
+Brought the existing codebase up to the new strictness:
+
+- Annotated `__init__` returns in `app/core/exceptions.py` (5 classes).
+- Replaced untyped `dict` annotations and added `EventDict` / `WrappedLogger` in `app/core/logger.py`; assigned local for the `BoundLogger` return.
+- Added `AsyncEngine` annotation on `Database.get_engine()` in `app/core/database.py`.
+- Added `dict[str, str]` on `liveness()` return in `app/routers/health.py`.
+- Added `DependsParam` annotation on `require_permission()` and a `cast` on its return in `app/core/security.py`.
+- Parameterized `Select` and `InstrumentedAttribute` generics in `app/utils/pagination.py`; annotated `decode_cursor` local; added `from exc` to the re-raise.
+- Replaced tuple-form `isinstance(..., (X, Y))` with `X | Y` in `app/services/audit_service.py` and `app/utils/pagination.py`.
+- Broke 3 long lines in `app/models/models.py`, `app/schemas/schemas.py`, and `tests/test_cross_cutting/test_error_responses.py`.
+- Auto-fix from `ruff --fix` removed unused imports in `app/core/database.py`, `app/routers/compliance.py`, `tests/test_compliance/test_audit_log.py`, `tests/test_cross_cutting/test_pagination.py`, and reorganized import blocks per `I001`.
+- Ran `ruff format` once across `app/` and `tests/` to baseline formatting (15 files reformatted, 24 already correct).
+
+Final state:
+- `docker compose exec backend ruff check app/ tests/` — clean.
+- `docker compose exec backend ruff format --check app/ tests/` — 39 files already formatted.
+- `docker compose exec backend mypy app/` — Success, no issues in 22 source files.
+- `pytest tests/ --no-cov` — 77 passed (3 pre-existing health-readiness failures on `tests/test_cross_cutting/test_health.py` exist on `main` and are unrelated to this task).
+
+## Decisions Made
+
+- **Ruff rule selection kept pragmatic per task notes** — `E, F, W, I, B, UP, SIM, RUF` only. No `S` (bandit), `D` (docstrings), `ANN` (annotations) — those are noisy on this codebase and would force ignores rather than improvements.
+- **`B008` ignored globally** — FastAPI relies on `Depends(...)` defaults in handler signatures; the rule fires throughout otherwise.
+- **`SIM117` ignored globally** — combined `with` statements obscure async context boundaries; the existing nested style is intentional.
+- **`UP` excluded from alembic** — auto-generated migrations should not be rewritten to look modern; their literal form is part of their audit value.
+- **`pydantic.mypy` plugin enabled** — strict mode without it produces dozens of false positives on `BaseModel` subclasses, and we use Pydantic across schemas and settings.
+- **Tests kept under strict mode for return-type checking, but constructor and decorator strictness relaxed** — the suite uses pytest fixtures and `@pytest.fixture`/`@pytest_asyncio.fixture` decorators that don't carry strict-friendly signatures.
+- **`ruff format` applied once** — baseline the codebase now so CI (TASK-008B) can enforce formatting. The diff touches 15 files but is mechanical.
+
+## Deviations from Task
+
+- **Codebase changes beyond pyproject.toml**: the AC required the existing codebase to pass strict mypy and ruff. Achieving that required source edits across 17 files. The `Files` section of TASK-008C only listed `backend/pyproject.toml` — call this an under-specification rather than a deviation. Impact: none; the touched files are all annotated or formatted to match the new rules, and no behavior changed.
+- **`ruff format` baseline applied**: not explicitly required by the AC, but `ruff format --check` would otherwise fail in CI. Applying it once now is cheaper than spreading the formatting churn across every future PR. Impact: future PRs will see a clean format baseline.
+
+## Open Items
+
+- Three pre-existing readiness tests in `tests/test_cross_cutting/test_health.py` fail on both `main` and this branch (`test_readiness_returns_200_when_db_ok`, `test_readiness_status_is_ready_when_db_ok`, `test_readiness_checks_dict_contains_database_ok`). Not in scope here — TASK-005 still has open ACs for `/health/ready`. Will need to be addressed before TASK-008B can ship a fully-green CI.

--- a/tasks/TASK-008C-linter-config.md
+++ b/tasks/TASK-008C-linter-config.md
@@ -1,6 +1,6 @@
 # TASK-008C: Linter & Type-Check Configuration
 
-**Status:** Not started
+**Status:** Complete
 **Spec sections:** SPEC-007 §14.1 (lint, type-check stages)
 **ADRs:** —
 **Depends on:** TASK-001 (dev dependencies installed)
@@ -11,14 +11,14 @@ Write the `[tool.ruff]` and `[tool.mypy]` sections in `backend/pyproject.toml` s
 
 ## Acceptance Criteria
 
-- [ ] `backend/pyproject.toml` contains a `[tool.ruff]` section with an explicit rule selection (at minimum: `E`, `F`, `W`, `I`, `B`, `UP`, `SIM`, `RUF`) and an explicit `line-length`
-- [ ] `[tool.ruff.lint.per-file-ignores]` carves out reasonable exceptions for test files (e.g., allow `S101` assert usage, unused-argument for fixtures) and Alembic migrations (auto-generated — ignore `E501`, `F401`)
-- [ ] `[tool.ruff.format]` section present so `ruff format` behaviour is stable across machines
-- [ ] `[tool.mypy]` section with `strict = true` per SPEC-007 §14.1, plus `python_version = "3.12"`
-- [ ] `[[tool.mypy.overrides]]` blocks relax strictness for test files and third-party modules that lack type stubs (e.g., `factory_boy`), so strict mode is achievable without rewriting tests
-- [ ] `docker compose exec backend ruff check app/ tests/` runs clean on the existing codebase (fix lint violations or add targeted ignores — do not disable whole rule families to make the suite pass)
-- [ ] `docker compose exec backend mypy app/` runs clean on the existing codebase (add type annotations or targeted `# type: ignore[code]` comments; do not lower strictness globally to pass)
-- [ ] The commands documented in `CLAUDE.md` (`ruff check app/ tests/`, `ruff format app/ tests/`, `mypy app/`) continue to work unchanged — this task only adds config, not new commands
+- [x] `backend/pyproject.toml` contains a `[tool.ruff]` section with an explicit rule selection (at minimum: `E`, `F`, `W`, `I`, `B`, `UP`, `SIM`, `RUF`) and an explicit `line-length`
+- [x] `[tool.ruff.lint.per-file-ignores]` carves out reasonable exceptions for test files (e.g., allow `S101` assert usage, unused-argument for fixtures) and Alembic migrations (auto-generated — ignore `E501`, `F401`)
+- [x] `[tool.ruff.format]` section present so `ruff format` behaviour is stable across machines
+- [x] `[tool.mypy]` section with `strict = true` per SPEC-007 §14.1, plus `python_version = "3.12"`
+- [x] `[[tool.mypy.overrides]]` blocks relax strictness for test files and third-party modules that lack type stubs (e.g., `factory_boy`), so strict mode is achievable without rewriting tests
+- [x] `docker compose exec backend ruff check app/ tests/` runs clean on the existing codebase (fix lint violations or add targeted ignores — do not disable whole rule families to make the suite pass)
+- [x] `docker compose exec backend mypy app/` runs clean on the existing codebase (add type annotations or targeted `# type: ignore[code]` comments; do not lower strictness globally to pass)
+- [x] The commands documented in `CLAUDE.md` (`ruff check app/ tests/`, `ruff format app/ tests/`, `mypy app/`) continue to work unchanged — this task only adds config, not new commands
 
 ## Files
 


### PR DESCRIPTION
## Summary
- Adds `[tool.ruff]` (`E,F,W,I,B,UP,SIM,RUF`, line-length 100, format config) and `[tool.mypy]` (`strict=true`, py312, pydantic plugin) to `backend/pyproject.toml`, with per-file-ignores for tests/alembic and overrides for `factory_boy`.
- Annotates returns, parameterizes `Select` / `InstrumentedAttribute` generics, replaces tuple-form `isinstance`, and applies a one-time `ruff format` baseline so the codebase passes the new strict gates.
- Closes the AC checkboxes for [TASK-008C](tasks/TASK-008C-linter-config.md); log at [task-logs/TASK-008C-log.md](task-logs/TASK-008C-log.md). This branch (`phase1-finish`) will also carry TASK-007, 008, and 008B per the bundling decision.

## Verification
- `docker compose exec backend ruff check app/ tests/` — clean
- `docker compose exec backend ruff format --check app/ tests/` — 39 files already formatted
- `docker compose exec backend mypy app/` — Success, no issues in 22 source files
- `pytest tests/ --no-cov` — 77 passed; 3 readiness tests in `tests/test_cross_cutting/test_health.py` fail on **both** this branch and `main` (pre-existing, flagged as a TASK-008B blocker)

## Test plan
- [ ] `docker compose exec backend ruff check app/ tests/` is clean
- [ ] `docker compose exec backend mypy app/` is clean
- [ ] `docker compose exec backend pytest tests/ --no-cov` is no worse than `main` (pre-existing health-readiness failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)