### PR TITLE
TASK-007: request-logging middleware + PHI exclusion tests

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,8 @@
 # STATE.md — Session Entry Point
 
 **Last updated:** 2026-04-29
-**Active task:** TASK-007 (next on phase1-finish branch)
-**Branch:** phase1-finish
+**Active task:** TASK-008 (next)
+**Branch:** task-007-request-logging
 
 ---
 
@@ -28,7 +28,7 @@
 | 004 | [Cursor pagination utility](tasks/TASK-004-cursor-pagination.md) | **Complete** | 001, 003 |
 | 005 | [Health check endpoints](tasks/TASK-005-health-check-endpoints.md) | **Complete** | 001 |
 | 006 | [AuditLog model & audit service](tasks/TASK-006-audit-log-model-and-service.md) | **Complete** | 001, 002 |
-| 007 | [Structured logging & PHI exclusion filter](tasks/TASK-007-structured-logging-phi-filter.md) | Partial | 001 |
+| 007 | [Structured logging & PHI exclusion filter](tasks/TASK-007-structured-logging-phi-filter.md) | **Complete** | 001 |
 | 008 | [Test infrastructure & fixtures](tasks/TASK-008-test-infrastructure.md) | Partial | 001, 002, 003, 007 |
 | 008A | [Service & router layer conventions (shared plumbing only)](tasks/TASK-008A-service-router-conventions.md) | Partial | 002, 003, 004, 006, 007, 008 |
 | 008B | [CI pipeline configuration (GitHub Actions: lint, type check, tests, build)](tasks/TASK-008B-ci-pipeline.md) | Not started | 001, 002, 007, 008, 008C |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.core.exceptions import GroundworkError
 from app.core.lifespan import lifespan
 from app.core.logger import get_logger
 from app.core.settings import settings
+from app.middleware.request_logger import RequestLoggerMiddleware
 from app.routers import compliance as compliance_router
 from app.routers import health as health_router
 
@@ -57,6 +58,12 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Request logger — added last so it wraps outermost and sees the
+    # client-visible status code after CORS and exception handling.
+    # SPEC-006 §4 BR-08: PHI is stripped by the structlog phi_filter
+    # processor, so payload field names safe to use here.
+    app.add_middleware(RequestLoggerMiddleware)
 
     # Domain errors — GroundworkError subclasses (SPEC-007 §7.3)
     @app.exception_handler(GroundworkError)

--- a/backend/app/middleware/request_logger.py
+++ b/backend/app/middleware/request_logger.py
@@ -1,0 +1,73 @@
+"""
+Request-logging middleware (SPEC-006 §4 BR-08, TASK-007 AC).
+
+Emits one structlog event per HTTP request with `method`, `path`,
+`status_code`, and `duration_ms`. The shared phi_filter is in the
+structlog processor chain, so any field name in PHI_EXCLUDED_FIELDS is
+stripped before emission regardless of what is bound to the logger.
+
+Implemented as pure ASGI middleware rather than `BaseHTTPMiddleware`
+to avoid the streaming-response and exception-propagation pitfalls of
+the latter. We always emit the log line, even when the downstream app
+raises — the exception is re-raised after logging so FastAPI's exception
+handlers run as usual.
+"""
+
+import time
+from typing import Any
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.logger import get_logger
+
+logger = get_logger("app.request")
+
+
+class RequestLoggerMiddleware:
+    """ASGI middleware that emits one log event per HTTP request."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        method: str = scope.get("method", "")
+        path: str = scope.get("path", "")
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception:
+            duration_ms = round((time.perf_counter() - start) * 1000, 2)
+            _emit(method=method, path=path, status_code=500, duration_ms=duration_ms)
+            raise
+
+        duration_ms = round((time.perf_counter() - start) * 1000, 2)
+        _emit(method=method, path=path, status_code=status_code, duration_ms=duration_ms)
+
+
+def _emit(*, method: str, path: str, status_code: int, duration_ms: float) -> None:
+    """Emit one structured log event for the request.
+
+    Kept as a free function so tests can assert on the exact field set
+    (method, path, status_code, duration_ms) without reaching into the
+    middleware class.
+    """
+    payload: dict[str, Any] = {
+        "method": method,
+        "path": path,
+        "status_code": status_code,
+        "duration_ms": duration_ms,
+    }
+    logger.info("request", **payload)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,10 +14,24 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-from app.core.database import Base
+from app.core.database import Base, Database
 from app.core.dependencies import get_db
 from app.core.settings import settings
 from app.main import create_app
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
+async def initialize_database() -> AsyncGenerator[None, None]:
+    """Initialize the production Database singleton against the test DB.
+
+    The FastAPI lifespan does not run under ``httpx.ASGITransport``, so any
+    code that touches ``Database.get_engine()`` (e.g. the readiness probe in
+    ``app/routers/health.py``) would otherwise see an uninitialized engine
+    and report ``"error"``. Initializing here mirrors production startup.
+    """
+    Database.initialize(settings.test_database_url)
+    yield
+    await Database.dispose()
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session")

--- a/backend/tests/test_cross_cutting/test_phi_exclusion.py
+++ b/backend/tests/test_cross_cutting/test_phi_exclusion.py
@@ -1,0 +1,107 @@
+"""
+PHI exclusion tests for structured logging (SPEC-006 §4 BR-08).
+
+The two named tests below are required by:
+  - SPEC-004 §10: test_note_content_excluded_from_application_logs
+  - SPEC-005 §8:  test_icd_codes_excluded_from_application_logs
+
+The phi_filter processor is wired into the structlog chain by setup_logging()
+(see app.core.logger). These tests call the filter directly so they cover
+exactly what gets emitted to log output, without depending on logger setup
+side effects from other tests.
+"""
+
+from app.core.logger import phi_filter
+from app.core.phi import PHI_EXCLUDED_FIELDS
+
+
+def test_note_content_excluded_from_application_logs() -> None:
+    """SPEC-004 §10 — clinical-note content keys must never reach log output.
+
+    Asserts every BR-08 clinical-note format key (subjective, objective,
+    assessment, plan, data, intervention, response, behavior) plus the
+    JSONB container fields (content, note_content) are stripped, while
+    non-PHI metadata around them is preserved.
+    """
+    event = {
+        "event": "note_saved",
+        "note_id": "00000000-0000-0000-0000-000000000001",
+        "actor_id": "00000000-0000-0000-0000-000000000002",
+        # All eight BR-08 format keys
+        "subjective": "Client reports increased anxiety this week.",
+        "objective": "Affect constricted; speech pressured.",
+        "assessment": "Generalized anxiety disorder, recurrent.",
+        "plan": "Continue weekly CBT; review medication next session.",
+        "data": "Reviewed thought log entries.",
+        "intervention": "Practiced 4-7-8 breathing.",
+        "response": "Reported reduced acute anxiety.",
+        "behavior": "Maintained eye contact, appropriate engagement.",
+        # JSONB container fields
+        "content": {"subjective": "...", "objective": "..."},
+        "note_content": "Free-text clinical narrative.",
+    }
+
+    filtered = phi_filter(None, "info", event)
+
+    for phi_field in (
+        "subjective",
+        "objective",
+        "assessment",
+        "plan",
+        "data",
+        "intervention",
+        "response",
+        "behavior",
+        "content",
+        "note_content",
+    ):
+        assert phi_field not in filtered, f"{phi_field} leaked into log event"
+
+    # Non-PHI metadata must survive — log records still need to be useful.
+    assert filtered["event"] == "note_saved"
+    assert filtered["note_id"] == "00000000-0000-0000-0000-000000000001"
+    assert filtered["actor_id"] == "00000000-0000-0000-0000-000000000002"
+
+
+def test_icd_codes_excluded_from_application_logs() -> None:
+    """SPEC-005 §8 — diagnosis codes correlated to a person are PHI per BR-08.
+
+    Both spellings used in InvoiceLineItem context (icd_codes, diagnosis_codes)
+    are stripped, while the surrounding billing identifiers are preserved.
+    """
+    event = {
+        "event": "invoice_line_item_created",
+        "invoice_id": "00000000-0000-0000-0000-000000000010",
+        "line_item_id": "00000000-0000-0000-0000-000000000011",
+        "cpt_code": "90837",
+        "amount_cents": 18000,
+        # Both PHI spellings — one or the other tends to show up depending on caller
+        "icd_codes": ["F33.1", "F41.1"],
+        "diagnosis_codes": ["F33.1"],
+    }
+
+    filtered = phi_filter(None, "info", event)
+
+    assert "icd_codes" not in filtered, "icd_codes leaked into log event"
+    assert "diagnosis_codes" not in filtered, "diagnosis_codes leaked into log event"
+
+    # Non-PHI billing identifiers must survive.
+    assert filtered["event"] == "invoice_line_item_created"
+    assert filtered["invoice_id"] == "00000000-0000-0000-0000-000000000010"
+    assert filtered["cpt_code"] == "90837"
+    assert filtered["amount_cents"] == 18000
+
+
+def test_phi_filter_centralized_list_is_authoritative() -> None:
+    """Belt-and-braces: every name in PHI_EXCLUDED_FIELDS is stripped.
+
+    Guards against silent drift if a field is added to the centralized
+    list but the filter implementation regresses.
+    """
+    event: dict[str, object] = {"event": "test"} | {field: "leak" for field in PHI_EXCLUDED_FIELDS}
+
+    filtered = phi_filter(None, "info", event)
+
+    for field in PHI_EXCLUDED_FIELDS:
+        assert field not in filtered, f"{field} listed in PHI_EXCLUDED_FIELDS but not stripped"
+    assert filtered["event"] == "test"

--- a/backend/tests/test_cross_cutting/test_request_logging.py
+++ b/backend/tests/test_cross_cutting/test_request_logging.py
@@ -1,0 +1,87 @@
+"""
+Tests for the request-logging middleware (TASK-007).
+
+Asserts that every HTTP request produces one structlog event whose
+fields include `method`, `path`, `status_code`, and `duration_ms`,
+and that the same event is emitted on the 5xx unhandled-exception
+path so monitoring is not blind during outages.
+
+Uses ``structlog.testing.capture_logs`` rather than pytest's caplog,
+because structlog kwargs are rendered into the LogRecord message — they
+are not preserved as record attributes for caplog to inspect.
+"""
+
+from collections.abc import MutableMapping
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+
+
+@pytest_asyncio.fixture
+async def app_with_failing_route() -> FastAPI:
+    """App that has an extra route which raises so we can exercise the 500 path."""
+    app = create_app()
+
+    @app.get("/test/explode")
+    async def explode() -> None:
+        raise RuntimeError("boom")
+
+    return app
+
+
+def _request_events(
+    captured: list[MutableMapping[str, Any]],
+) -> list[MutableMapping[str, Any]]:
+    """Filter captured events down to the ones emitted by the middleware."""
+    return [e for e in captured if e.get("event") == "request"]
+
+
+@pytest.mark.asyncio
+async def test_request_logger_emits_required_fields_on_200(client: AsyncClient) -> None:
+    """The middleware emits method/path/status_code/duration_ms on a successful request."""
+    with structlog.testing.capture_logs() as captured:
+        response = await client.get("/api/v1/health")
+
+    assert response.status_code == 200
+
+    events = _request_events(captured)
+    assert len(events) >= 1
+
+    event = events[-1]
+    assert event["method"] == "GET"
+    assert event["path"] == "/api/v1/health"
+    assert event["status_code"] == 200
+    assert isinstance(event["duration_ms"], float)
+    assert event["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_request_logger_emits_event_on_unhandled_500(
+    app_with_failing_route: FastAPI,
+) -> None:
+    """Unhandled exceptions still produce a request-log event with status_code=500.
+
+    ``raise_app_exceptions=False`` so the test sees the 500 response from
+    Starlette's ServerErrorMiddleware rather than re-raising into pytest.
+    """
+    transport = ASGITransport(app=app_with_failing_route, raise_app_exceptions=False)
+    with structlog.testing.capture_logs() as captured:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/test/explode")
+
+    assert response.status_code == 500
+
+    events = _request_events(captured)
+    explode_events = [e for e in events if e.get("path") == "/test/explode"]
+    assert len(explode_events) >= 1
+
+    event = explode_events[-1]
+    assert event["method"] == "GET"
+    assert event["status_code"] == 500
+    assert isinstance(event["duration_ms"], float)

--- a/task-logs/TASK-007-log.md
+++ b/task-logs/TASK-007-log.md
@@ -1,0 +1,38 @@
+# TASK-007 Log — Structured Logging & PHI Exclusion Filter
+
+**Agent:** claude-code
+**Branch:** task-007-request-logging
+**Date completed:** 2026-04-29
+
+## What Was Done
+
+The PHI exclusion filter and centralized field list shipped earlier (TASK-006 amendment 2026-04-23). This task closed the two remaining gaps:
+
+1. **Request-logging middleware** — `app/middleware/request_logger.py` with `RequestLoggerMiddleware`, a pure-ASGI middleware that emits one structlog event per HTTP request with `method`, `path`, `status_code`, and `duration_ms`. Registered in `app/main.py` after `CORSMiddleware` so it wraps outermost and observes the client-visible status. The 5xx exception path is wrapped in try/except so a log line is still emitted (with `status_code=500`) before the exception is re-raised to FastAPI's handlers.
+2. **Two named tests** — `tests/test_cross_cutting/test_phi_exclusion.py` covers `test_note_content_excluded_from_application_logs` (SPEC-004 §10) and `test_icd_codes_excluded_from_application_logs` (SPEC-005 §8), plus a third regression-guard test that asserts every name in `PHI_EXCLUDED_FIELDS` is stripped (catches drift between the centralized list and the filter implementation).
+3. **Middleware tests** — `tests/test_cross_cutting/test_request_logging.py` exercises the 200 path (asserts the four required fields are present and correctly typed) and the 500 path (asserts an event is still emitted on unhandled exception). Uses `structlog.testing.capture_logs` rather than pytest's `caplog`, because structlog renders kwargs into the LogRecord message instead of attaching them as attributes.
+4. **Readiness fixture fix** — `tests/conftest.py` now has a session-scoped autouse `initialize_database` fixture that calls `Database.initialize(settings.test_database_url)` before tests run, mirroring what the FastAPI lifespan does in production. The lifespan does not fire under `httpx.ASGITransport`, so `_check_database` in `app/routers/health.py` was previously seeing an uninitialized engine and reporting `"error"`. Three readiness tests that had been failing on `main` now pass.
+
+Final state:
+- `docker compose exec backend ruff check app/ tests/` — clean.
+- `docker compose exec backend ruff format --check app/ tests/` — 43 files already formatted.
+- `docker compose exec backend mypy app/` — Success, no issues in 24 source files.
+- `docker compose exec backend pytest tests/ --no-cov` — 91 passed, 0 failed.
+
+## Decisions Made
+
+- **Pure ASGI middleware over `BaseHTTPMiddleware`.** `BaseHTTPMiddleware` interferes with streaming responses and swallows exceptions in ways that complicate the always-emit guarantee. The pure ASGI form is ~30 lines and avoids both pitfalls.
+- **Logger added last in `create_app`.** Starlette wraps middleware in registration order with the *last* added being the *outermost*. Adding `RequestLoggerMiddleware` after CORS means it sees the client-visible status code (after CORS has run) rather than the inner-app status.
+- **Did not log query strings.** `scope["path"]` only — query strings can carry PHI in poorly-designed clients (e.g. `?ssn=...`), and the PHI filter only inspects field names. Logging the path alone is the conservative default.
+- **`structlog.testing.capture_logs` for middleware tests.** caplog is the obvious first choice but structlog's stdlib LoggerFactory renders kwargs into the message string rather than attaching them as record attributes, so caplog can't assert on individual fields. Documented in the test module docstring.
+- **Third PHI test added beyond the spec's two.** `test_phi_filter_centralized_list_is_authoritative` is a regression guard that fails if a future edit adds a name to `PHI_EXCLUDED_FIELDS` but breaks the filter. Cheap to maintain, and mirrors the "single source of truth" intent of SPEC-006 §7.
+
+## Deviations from Task
+
+- **Task file `Files` section listed `app/middleware/` as the implementation home but the directory did not exist.** Created `backend/app/middleware/__init__.py` (empty) alongside `request_logger.py`. Impact: none; SPEC-007 §561 already lists `middleware/` in the expected layout.
+- **Task description's "Remaining" line claimed the PHI list also needed expanding.** That work shipped under TASK-006 amendment 2026-04-23. The centralized list in `app/core/phi.py` already covers the full BR-08 set, so the AC bullet was simply ticked rather than re-implemented. Documented in the AC update.
+
+## Open Items
+
+- TASK-005 may now be effectively complete: `/health` returns `{"status": "ok", ...}`, `/health/ready` exists in `app/routers/health.py` with the DB probe, and all 9 health tests pass on this branch. Worth a separate review/flip in STATE.md.
+- Request logger does not yet emit a `request_id` correlation ID — that's owned by TASK-014 (auth middleware) where request scoping is wired up. Not in scope here.

--- a/tasks/TASK-007-structured-logging-phi-filter.md
+++ b/tasks/TASK-007-structured-logging-phi-filter.md
@@ -1,6 +1,6 @@
 # TASK-007: Structured Logging & PHI Exclusion Filter
 
-**Status:** Partial
+**Status:** Complete
 **Spec sections:** SPEC-006 §4 (BR-08); SPEC-000 §6
 **ADRs:** —
 **Depends on:** TASK-001
@@ -12,12 +12,12 @@ Configure structlog with JSON output and a PHI field exclusion filter at the ser
 ## Acceptance Criteria
 
 - [x] structlog configured with JSON output format — `setup_logging()` in `app/core/logger.py`
-- [ ] PHI exclusion filter strips: clinical note content keys (subjective, objective, assessment, plan, data, intervention, response, behavior), diagnosis codes, date_of_birth, ClientConsent.notes, Document free-text, and AttributeValue.value — filter exists with 7 fields (`note_content`, `date_of_birth`, `dob`, `diagnosis_codes`, `icd_codes`, `ssn`, `social_security`); missing clinical note keys, `ClientConsent.notes`, `Document` free-text, `AttributeValue.value`
+- [x] PHI exclusion filter strips: clinical note content keys (subjective, objective, assessment, plan, data, intervention, response, behavior), diagnosis codes, date_of_birth, ClientConsent.notes, Document free-text, and AttributeValue.value — full BR-08 list shipped via `PHI_EXCLUDED_FIELDS` in `app/core/phi.py`
 - [x] Filter is applied at the serializer layer (not per-call) — no PHI can bypass the filter — `phi_filter` wired into the structlog processor chain
 - [x] Filter is a single centralized list, not per-endpoint per SPEC-006 §4 — `PHI_FIELDS` frozenset in `app/core/logger.py`
-- [ ] Test: `test_note_content_excluded_from_application_logs` (SPEC-004 §10)
-- [ ] Test: `test_icd_codes_excluded_from_application_logs` (SPEC-005 §8)
-- [ ] Log output includes request metadata: method, path, status code, duration — no request-logging middleware yet
+- [x] Test: `test_note_content_excluded_from_application_logs` (SPEC-004 §10)
+- [x] Test: `test_icd_codes_excluded_from_application_logs` (SPEC-005 §8)
+- [x] Log output includes request metadata: method, path, status code, duration — `RequestLoggerMiddleware` in `app/middleware/request_logger.py`
 
 **Done so far (in code):** structlog + JSON processor + `phi_filter` with 7 fields, wired via `setup_logging()`.
 


### PR DESCRIPTION
## Summary
- Adds `RequestLoggerMiddleware` (pure ASGI) at [backend/app/middleware/request_logger.py](backend/app/middleware/request_logger.py) emitting `method`, `path`, `status_code`, `duration_ms` per request. Registered after CORS so it wraps outermost. Always emits, even on unhandled exception.
- Adds the two SPEC-named tests at [backend/tests/test_cross_cutting/test_phi_exclusion.py](backend/tests/test_cross_cutting/test_phi_exclusion.py): `test_note_content_excluded_from_application_logs` (SPEC-004 §10) and `test_icd_codes_excluded_from_application_logs` (SPEC-005 §8), plus a regression-guard test that fails if `PHI_EXCLUDED_FIELDS` drifts from the filter implementation.
- Adds middleware tests at [backend/tests/test_cross_cutting/test_request_logging.py](backend/tests/test_cross_cutting/test_request_logging.py) for both 200 and 500 paths. Uses `structlog.testing.capture_logs` (caplog can't see structlog kwargs).
- **Bonus fix**: `conftest.py` now initializes `Database` against the test DB in a session-scoped autouse fixture, mirroring the lifespan that `httpx.ASGITransport` doesn't run. This unblocks the 3 readiness tests in [test_health.py](backend/tests/test_cross_cutting/test_health.py) that had been failing on `main`.
- Closes [TASK-007](tasks/TASK-007-structured-logging-phi-filter.md). May also close TASK-005 — flagged as an open item in [task-logs/TASK-007-log.md](task-logs/TASK-007-log.md) for separate review.

## Verification
- `docker compose exec backend ruff check app/ tests/` — clean
- `docker compose exec backend ruff format --check app/ tests/` — 43 files already formatted
- `docker compose exec backend mypy app/` — Success, no issues in 24 source files
- `docker compose exec backend pytest tests/ --no-cov` — **91 passed, 0 failed** (was 88 + 3 failing on the prior branch)

## Test plan
- [ ] `docker compose exec backend ruff check app/ tests/` is clean
- [ ] `docker compose exec backend mypy app/` is clean
- [ ] `docker compose exec backend pytest tests/ --no-cov` is fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)