### PR TITLE
TASK-008: JWT test fixtures + coverage gate

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,8 @@
 # STATE.md — Session Entry Point
 
 **Last updated:** 2026-04-29
-**Active task:** TASK-008 (next)
-**Branch:** task-007-request-logging
+**Active task:** TASK-008B (next)
+**Branch:** task-008-test-infrastructure
 
 ---
 
@@ -29,7 +29,7 @@
 | 005 | [Health check endpoints](tasks/TASK-005-health-check-endpoints.md) | **Complete** | 001 |
 | 006 | [AuditLog model & audit service](tasks/TASK-006-audit-log-model-and-service.md) | **Complete** | 001, 002 |
 | 007 | [Structured logging & PHI exclusion filter](tasks/TASK-007-structured-logging-phi-filter.md) | **Complete** | 001 |
-| 008 | [Test infrastructure & fixtures](tasks/TASK-008-test-infrastructure.md) | Partial | 001, 002, 003, 007 |
+| 008 | [Test infrastructure & fixtures](tasks/TASK-008-test-infrastructure.md) | **Complete** (per-domain factories deferred) | 001, 002, 003, 007 |
 | 008A | [Service & router layer conventions (shared plumbing only)](tasks/TASK-008A-service-router-conventions.md) | Partial | 002, 003, 004, 006, 007, 008 |
 | 008B | [CI pipeline configuration (GitHub Actions: lint, type check, tests, build)](tasks/TASK-008B-ci-pipeline.md) | Not started | 001, 002, 007, 008, 008C |
 | 008C | [Linter & type-check configuration (ruff + mypy strict in pyproject.toml)](tasks/TASK-008C-linter-config.md) | **Complete** | 001 |

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,6 +3,6 @@ asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
 testpaths = tests
-addopts = --cov=app --cov-report=term-missing --strict-markers
+addopts = --cov=app --cov-report=term-missing --cov-fail-under=90 --strict-markers
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,8 +5,10 @@ Each test runs inside a transaction that is rolled back after the test completes
 ensuring full isolation without needing to recreate tables between tests.
 """
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
+from typing import Any
 
+import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import (
@@ -18,6 +20,9 @@ from app.core.database import Base, Database
 from app.core.dependencies import get_db
 from app.core.settings import settings
 from app.main import create_app
+from tests.fixtures import jwt_keys
+
+TokenFactory = Callable[..., str]
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
@@ -83,4 +88,48 @@ async def client(db_session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
 
-    # TODO: Phase 2 - Add JWT test fixture for authenticated requests
+
+# ---------------------------------------------------------------------------
+# Auth fixtures (SPEC-007 §13.4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def test_public_key_pem() -> bytes:
+    """Public key the auth middleware will validate against (TASK-014)."""
+    return jwt_keys.PUBLIC_KEY_PEM
+
+
+@pytest.fixture(scope="session")
+def test_private_key_pem() -> bytes:
+    """Private key used to mint test tokens. Never used by production code."""
+    return jwt_keys.PRIVATE_KEY_PEM
+
+
+@pytest.fixture
+def make_token() -> TokenFactory:
+    """Return a callable that mints signed JWTs with overridable claims.
+
+    Defaults produce a token that the auth middleware (TASK-014) will accept.
+    Pass overrides to express negative-path scenarios:
+
+        make_token()                            # valid
+        make_token(exp_offset=-60)              # expired
+        make_token(iss="https://attacker/")     # wrong issuer
+        make_token(extra_claims={"permissions": ["org:read"]})
+
+    The signature is a thin wrapper around ``jwt_keys.mint_token`` so tests
+    can stay declarative and the underlying minting helper stays free-function
+    callable from non-pytest contexts (e.g. integration scripts).
+    """
+
+    def _mint(**overrides: Any) -> str:
+        return jwt_keys.mint_token(**overrides)
+
+    return _mint
+
+
+@pytest.fixture
+def auth_header(make_token: TokenFactory) -> dict[str, str]:
+    """Convenience: a ready-to-use Authorization header with a default valid token."""
+    return {"Authorization": f"Bearer {make_token()}"}

--- a/backend/tests/fixtures/jwt_keys.py
+++ b/backend/tests/fixtures/jwt_keys.py
@@ -1,0 +1,79 @@
+"""
+Test-only RSA key material and JWT minting helper (SPEC-007 §13.4, TASK-008).
+
+A fresh RSA keypair is generated once per process import and exposed as
+module-level PEM constants. Tests use ``mint_token(**overrides)`` to issue
+JWTs signed with the same private key. TASK-014 will configure the auth
+middleware to validate against ``PUBLIC_KEY_PEM`` from this module so the
+same keypair is used end-to-end without committing secrets.
+
+Generating fresh per process avoids checking key material into the repo
+and avoids any risk of a "test" key being mistaken for production.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from joserfc import jwt
+from joserfc.jwk import RSAKey
+
+
+def _generate_keypair() -> tuple[bytes, bytes]:
+    """Generate a 2048-bit RSA keypair and return (private_pem, public_pem)."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+PRIVATE_KEY_PEM, PUBLIC_KEY_PEM = _generate_keypair()
+
+TEST_ISSUER = "https://groundwork-test.local/"
+TEST_AUDIENCE = "https://api.groundwork.test/"
+TEST_KID = "groundwork-test-key"
+
+_PRIVATE_KEY = RSAKey.import_key(PRIVATE_KEY_PEM, parameters={"kid": TEST_KID})
+
+
+def mint_token(
+    *,
+    sub: str = "auth0|test-subject",
+    iss: str = TEST_ISSUER,
+    aud: str | list[str] = TEST_AUDIENCE,
+    exp_offset: int = 3600,
+    iat_offset: int = 0,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    """Mint a signed JWT for tests.
+
+    Defaults produce a valid token. Override ``exp_offset`` to make the
+    token expired (negative seconds), ``iss`` / ``aud`` to test rejection
+    paths, and pass ``extra_claims`` for custom claims (e.g. permissions).
+    """
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "sub": sub,
+        "iss": iss,
+        "aud": aud,
+        "iat": now + iat_offset,
+        "exp": now + exp_offset,
+    }
+    if extra_claims:
+        claims.update(extra_claims)
+
+    return jwt.encode(
+        {"alg": "RS256", "kid": TEST_KID, "typ": "JWT"},
+        claims,
+        _PRIVATE_KEY,
+    )

--- a/backend/tests/test_cross_cutting/test_jwt_fixture.py
+++ b/backend/tests/test_cross_cutting/test_jwt_fixture.py
@@ -1,0 +1,118 @@
+"""
+Tests for the JWT test fixtures (SPEC-007 §13.4, TASK-008).
+
+Asserts that:
+  * The session-scoped key fixtures expose PEM-encoded RSA keys.
+  * ``make_token`` mints tokens that decode + verify against the public key.
+  * Claim overrides (sub, iss, aud, exp, extra_claims) are respected so
+    negative-path tests can be expressed without reimplementing the encoder.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, cast
+
+import pytest
+from joserfc import jwt
+from joserfc.errors import BadSignatureError
+from joserfc.jwk import RSAKey
+
+from tests.conftest import TokenFactory
+
+
+def _decode(token: str, public_pem: bytes) -> dict[str, Any]:
+    """Verify signature against the test public key and return the claims."""
+    key = RSAKey.import_key(public_pem)
+    decoded = jwt.decode(token, key)
+    return cast(dict[str, Any], decoded.claims)
+
+
+def test_public_and_private_keys_are_pem_encoded(
+    test_public_key_pem: bytes,
+    test_private_key_pem: bytes,
+) -> None:
+    assert test_public_key_pem.startswith(b"-----BEGIN PUBLIC KEY-----")
+    assert test_private_key_pem.startswith(b"-----BEGIN PRIVATE KEY-----")
+
+
+def test_make_token_default_is_valid(
+    make_token: TokenFactory,
+    test_public_key_pem: bytes,
+) -> None:
+    token = make_token()
+    claims = _decode(token, test_public_key_pem)
+
+    assert claims["sub"] == "auth0|test-subject"
+    assert claims["iss"] == "https://groundwork-test.local/"
+    assert claims["aud"] == "https://api.groundwork.test/"
+    assert claims["exp"] > int(time.time())
+    assert claims["iat"] <= int(time.time()) + 1
+
+
+def test_make_token_overrides_subject_and_audience(
+    make_token: TokenFactory,
+    test_public_key_pem: bytes,
+) -> None:
+    token = make_token(sub="auth0|alice", aud="https://other-api/")
+    claims = _decode(token, test_public_key_pem)
+
+    assert claims["sub"] == "auth0|alice"
+    assert claims["aud"] == "https://other-api/"
+
+
+def test_make_token_can_produce_expired_token(
+    make_token: TokenFactory,
+    test_public_key_pem: bytes,
+) -> None:
+    """Negative-path scenario: middleware in TASK-014 must reject this."""
+    token = make_token(exp_offset=-60)
+    claims = _decode(token, test_public_key_pem)
+
+    assert claims["exp"] < int(time.time())
+
+
+def test_make_token_can_inject_custom_claims(
+    make_token: TokenFactory,
+    test_public_key_pem: bytes,
+) -> None:
+    """Custom claims (e.g. permissions) flow through unchanged."""
+    token = make_token(extra_claims={"permissions": ["org:read", "org:write"]})
+    claims = _decode(token, test_public_key_pem)
+
+    assert claims["permissions"] == ["org:read", "org:write"]
+
+
+def test_make_token_signature_validates_against_test_public_key_only(
+    make_token: TokenFactory,
+    test_public_key_pem: bytes,
+) -> None:
+    """Sanity: another keypair must not validate the token.
+
+    Guards against an accidental hard-coded constant: if someone ever
+    short-circuits ``mint_token`` to use a static key, this catches it.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    other_pem = (
+        rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        .public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+
+    token = make_token()
+    # Test key validates
+    _decode(token, test_public_key_pem)
+    # Foreign key does not — joserfc raises BadSignatureError on mismatch.
+    with pytest.raises(BadSignatureError):
+        _decode(token, other_pem)
+
+
+def test_auth_header_fixture_returns_bearer_token(auth_header: dict[str, str]) -> None:
+    assert "Authorization" in auth_header
+    assert auth_header["Authorization"].startswith("Bearer ")
+    assert len(auth_header["Authorization"]) > len("Bearer ")

--- a/task-logs/TASK-008-log.md
+++ b/task-logs/TASK-008-log.md
@@ -1,0 +1,39 @@
+# TASK-008 Log — Test Infrastructure & Fixtures
+
+**Agent:** claude-code
+**Branch:** task-008-test-infrastructure
+**Date completed:** 2026-04-29
+
+## What Was Done
+
+The DB fixtures (`db_session`, `client`, `test_engine`, `create_tables`) and the `tests/factories/` scaffold were already in place. This task closed the remaining ACs:
+
+1. **JWT test key material** — `backend/tests/fixtures/jwt_keys.py` generates a 2048-bit RSA keypair on first import and exposes `PRIVATE_KEY_PEM`, `PUBLIC_KEY_PEM`, `TEST_ISSUER`, `TEST_AUDIENCE`, `TEST_KID` as module constants, plus a `mint_token(...)` helper. Generated per-process rather than committed: there is zero risk of a "test" key being mistaken for production.
+2. **Token-minting fixture** — `make_token` fixture in `backend/tests/conftest.py` returns a callable wrapping `jwt_keys.mint_token`. Defaults produce a valid token; overrides expose `sub`, `iss`, `aud`, `exp_offset`, `iat_offset`, and `extra_claims` so negative paths (expired, wrong issuer, custom permissions) are one-liner. `auth_header` fixture pre-builds a `{"Authorization": "Bearer ..."}` dict for routine cases. Session-scoped `test_public_key_pem` / `test_private_key_pem` fixtures expose the keypair for TASK-014 to wire into the middleware.
+3. **Tests for the fixtures** — `backend/tests/test_cross_cutting/test_jwt_fixture.py` covers PEM encoding, default token validity, claim overrides (subject/audience), expired-token path, custom-claim injection, and a foreign-key signature rejection sanity check (catches accidental hard-coding).
+4. **Coverage gate** — `--cov-fail-under=90` added to `backend/pytest.ini` `addopts`. The existing `.coveragerc` `[report] fail_under = 90` is now enforced explicitly via pytest-cov rather than only at coverage-report time.
+
+Final state:
+- `docker compose exec backend ruff check app/ tests/` — clean.
+- `docker compose exec backend ruff format --check app/ tests/` — 46 files already formatted.
+- `docker compose exec backend mypy app/` — Success, no issues in 24 source files.
+- `docker compose exec backend pytest tests/` — **98 passed, 0 failed**, coverage 93.62% (gate: ≥ 90%).
+
+## Decisions Made
+
+- **Generate keypair per-process rather than commit it.** The AC said "may be generated at setup rather than committed" — generation eliminates any chance of a leaked test key being reused, and avoids a checked-in `.pem` that lints/secrets-scanners flag.
+- **`joserfc` over `pyjwt`/`python-jose`.** It is already an installed transitive dep via `auth0-fastapi-api`, and TASK-014 will use the same library to validate. Using one library end-to-end avoids API-surface drift between the test minter and the production validator.
+- **Module-level constants instead of env vars for the public key.** AC offered both. Module-level (`from tests.fixtures.jwt_keys import PUBLIC_KEY_PEM`) is one fewer indirection than env-var roundtripping, and the test middleware (TASK-014) will already be importing from the test tree to wire up overrides anyway.
+- **`make_token` returns a callable, not a token directly.** A single fixture lets one test mint multiple tokens with different claims (e.g. one valid, one expired in the same test). Cheap to do; saves an awkward parametrize otherwise.
+- **`auth_header` convenience fixture added.** Most tests will just want a valid `Authorization` header; the helper saves a line per test.
+- **Per-domain factories deferred.** Per the AC "(created in each domain task)" non-goal, only `app_factory.py` and `crud_factory.py` scaffolds remain. The Status line on the task explicitly notes this.
+
+## Deviations from Task
+
+- **`Files` listed `backend/.coveragerc` but it already exists with `fail_under = 90`.** No change needed there; the AC's "enforced in pytest config" clause was the actual missing piece. Added `--cov-fail-under=90` to `pytest.ini` addopts so the gate runs at test time, not just at report time.
+- **`tests/fixtures/jwt_keys/` directory in `Files` was not created — used `tests/fixtures/jwt_keys.py` (a module) instead.** A single module is cleaner than a directory of `.pem` files when keys are generated in-process.
+
+## Open Items
+
+- `app/routers/compliance.py` is at 61% line coverage (audit-log read endpoints largely untested by the cross-cutting suite). TASK-006's audit-log read tests already exist in `tests/test_compliance/test_audit_log.py` — the lines flagged are likely error paths. Worth a separate look but not in TASK-008's scope.
+- TASK-014 will need to either (a) wire `Settings.auth0_jwks_uri` to a synthetic JWKS endpoint backed by `tests.fixtures.jwt_keys.PUBLIC_KEY_PEM`, or (b) add a `Settings.auth0_test_public_key` field that the middleware uses when set. That choice belongs in TASK-014.

--- a/tasks/TASK-008-test-infrastructure.md
+++ b/tasks/TASK-008-test-infrastructure.md
@@ -1,6 +1,6 @@
 # TASK-008: Test Infrastructure & Fixtures
 
-**Status:** Partial
+**Status:** Complete (per-domain factories deferred to their domain tasks per AC note)
 **Spec sections:** SPEC-007 §13 (all subsections); SPEC-000 §5
 **ADRs:** —
 **Depends on:** TASK-001, TASK-002, TASK-003, TASK-007
@@ -13,13 +13,13 @@ Build the test infrastructure: conftest fixtures for database sessions with tran
 
 - [x] `conftest.py` provides an async SQLAlchemy session fixture with per-test transaction rollback per SPEC-007 §13.2 — `db_session` fixture wraps each test in a transaction and rolls back
 - [x] Test client uses `httpx.AsyncClient` with full middleware execution (no middleware bypass) per SPEC-007 §13.3 — `client` fixture via `ASGITransport(app=create_app())`
-- [ ] Test auth fixture generates valid JWTs signed with a test-only RSA key pair per SPEC-007 §13.4
-- [ ] Test RSA key pair is loaded from a fixed test location (env var `AUTH0_TEST_PRIVATE_KEY`/`AUTH0_TEST_PUBLIC_KEY` or file under `tests/fixtures/`), so TASK-014 can point the auth middleware at the same public key when it lands
-- [ ] Token fixture accepts overrides (sub, exp, aud, custom claims) so negative-path tests (expired, wrong issuer, missing sub) are expressible without reimplementing the encoder
+- [x] Test auth fixture generates valid JWTs signed with a test-only RSA key pair per SPEC-007 §13.4 — `make_token` fixture in `conftest.py`, RSA keypair in `tests/fixtures/jwt_keys.py`
+- [x] Test RSA key pair is loaded from a fixed test location (env var `AUTH0_TEST_PRIVATE_KEY`/`AUTH0_TEST_PUBLIC_KEY` or file under `tests/fixtures/`), so TASK-014 can point the auth middleware at the same public key when it lands — `tests/fixtures/jwt_keys.py` exposes `PUBLIC_KEY_PEM` / `PRIVATE_KEY_PEM` module constants; TASK-014 imports from there
+- [x] Token fixture accepts overrides (sub, exp, aud, custom claims) so negative-path tests (expired, wrong issuer, missing sub) are expressible without reimplementing the encoder
 - [~] Test factory pattern established with sensible defaults per SPEC-007 §13.5 — generic `app_factory.py` + `crud_factory.py` scaffolds exist under `tests/factories/`; per-domain factories (Organization, Person, etc.) not yet written
 - [x] Tests run via `docker compose exec backend pytest` against `db-test` on port 5433
-- [ ] Coverage measured by pytest-cov with `--cov-fail-under=90` enforced in pytest config (threshold: 90%)
-- [ ] `pytest.ini` or `pyproject.toml [tool.pytest]` configured with correct DB URL and coverage settings
+- [x] Coverage measured by pytest-cov with `--cov-fail-under=90` enforced in pytest config (threshold: 90%) — added to `pytest.ini` `addopts`
+- [x] `pytest.ini` or `pyproject.toml [tool.pytest]` configured with correct DB URL and coverage settings — `pytest.ini` carries `--cov` and `--cov-fail-under=90`; DB URL comes from `settings.test_database_url` (env-driven), used by `conftest.test_engine`
 - [x] Factory modules scaffolded under `tests/factories/` per SPEC-007 §13.6 — directory + scaffolds present; per-domain modules deferred to the respective domain tasks
 
 **Done so far (in code):** `conftest.py` with session-scoped engine, session-scoped table create/drop, per-test `db_session` with transaction rollback, `client` fixture with dependency override; `tests/factories/` scaffold with `app_factory.py` and `crud_factory.py`; domain test directories (`test_eav/`, `test_identity/`, `test_sessions/`, `test_notes/`, `test_billing/`, `test_compliance/`, `test_auth/`, `test_cross_cutting/`) exist.


### PR DESCRIPTION
## Summary
- Adds [backend/tests/fixtures/jwt_keys.py](backend/tests/fixtures/jwt_keys.py): per-process 2048-bit RSA keypair + `mint_token(...)` helper using `joserfc` (same library `auth0-fastapi-api` uses for validation).
- Adds `make_token`, `auth_header`, `test_public_key_pem`, `test_private_key_pem` fixtures to [backend/tests/conftest.py](backend/tests/conftest.py). `make_token` accepts `sub/iss/aud/exp_offset/iat_offset/extra_claims` overrides so negative-path tests are one-liners.
- 7 new tests in [backend/tests/test_cross_cutting/test_jwt_fixture.py](backend/tests/test_cross_cutting/test_jwt_fixture.py) cover PEM encoding, default validity, claim overrides, expired path, custom claims, and a foreign-key signature rejection sanity check.
- Adds `--cov-fail-under=90` to [backend/pytest.ini](backend/pytest.ini) `addopts` so coverage is enforced at test time, not just at report time.
- Closes [TASK-008](tasks/TASK-008-test-infrastructure.md) — per-domain factories remain deferred to their domain tasks per the explicit AC non-goal. Log at [task-logs/TASK-008-log.md](task-logs/TASK-008-log.md).

## Verification
- `docker compose exec backend ruff check app/ tests/` — clean
- `docker compose exec backend ruff format --check app/ tests/` — 46 files already formatted
- `docker compose exec backend mypy app/` — Success, no issues in 24 source files
- `docker compose exec backend pytest tests/` — **98 passed, 0 failed**, coverage **93.62%** (gate ≥ 90%)

## Test plan
- [ ] `docker compose exec backend ruff check app/ tests/` is clean
- [ ] `docker compose exec backend mypy app/` is clean
- [ ] `docker compose exec backend pytest tests/` passes with coverage ≥ 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)