### PR TITLE
TASK-008B: CI pipeline (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      # docker-compose.yml references .env and backend/.env.backend (both gitignored
+      # since they hold local-dev secrets). Compose treats `env_file:` paths as
+      # required by default and fails if they don't exist. In CI the defaults baked
+      # into compose's `${VAR:-default}` syntax and pydantic-settings' field
+      # defaults are sufficient, so empty stubs are enough.
+      - name: Create stub env files for compose
+        run: |
+          touch .env
+          touch backend/.env.backend
+
       # The backend image bakes pyproject.toml in, so any change there requires a rebuild.
       # The volume mount on app/ and tests/ keeps source iteration fast in dev — in CI we
       # are working from a fresh checkout so the mounted paths reflect the PR's tree.
@@ -86,6 +96,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Create stub env files for compose
+        run: |
+          touch .env
+          touch backend/.env.backend
 
       - name: Build backend image
         run: docker compose build backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # SPEC-007 §14.1 — lint → type check → tests inside Docker
+  backend-checks:
+    name: Lint, type check, tests (backend)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('backend/dockerfile', 'backend/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # The backend image bakes pyproject.toml in, so any change there requires a rebuild.
+      # The volume mount on app/ and tests/ keeps source iteration fast in dev — in CI we
+      # are working from a fresh checkout so the mounted paths reflect the PR's tree.
+      - name: Build backend image
+        run: docker compose build backend
+
+      - name: Start backend and test database
+        run: |
+          docker compose up -d backend db-test
+          # Wait for db-test to be healthy so pytest can connect. The compose
+          # `--wait` flag would block on the primary `db` healthcheck only;
+          # we poll docker inspect directly for the test DB.
+          for i in {1..30}; do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' groundwork-db-test-1 2>/dev/null || echo "starting")
+            if [ "$STATUS" = "healthy" ]; then
+              echo "db-test is healthy"
+              break
+            fi
+            echo "Waiting for db-test... ($i/30): $STATUS"
+            sleep 2
+          done
+          docker compose ps
+
+      - name: Lint (ruff check)
+        run: docker compose exec -T backend ruff check app/ tests/
+
+      - name: Format check (ruff format --check)
+        run: docker compose exec -T backend ruff format --check app/ tests/
+
+      - name: Type check (mypy strict)
+        run: docker compose exec -T backend mypy app/
+
+      # Coverage threshold (--cov-fail-under=90) is enforced by pytest config (TASK-008).
+      - name: Backend tests (pytest)
+        run: docker compose exec -T backend pytest
+
+      - name: Tear down compose
+        if: always()
+        run: docker compose down -v
+
+  # SPEC-007 §14.1 — build stage runs on its own so a build break is reportable
+  # even if the test stage above passes against a previously-cached image.
+  build:
+    name: Docker image build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        run: docker compose build backend
+

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Create stub env files for compose
+        run: |
+          touch .env
+          touch backend/.env.backend
+
       - name: Build backend image
         run: docker compose build backend
 

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -1,0 +1,68 @@
+name: Migration safety
+
+# SPEC-007 §14.3 — runs only when a PR or push touches an Alembic revision.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/alembic/versions/**'
+  push:
+    branches: [main]
+    paths:
+      - 'backend/alembic/versions/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-safety-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  migration-safety:
+    name: Apply, upgrade, downgrade
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        run: docker compose build backend
+
+      - name: Start primary database
+        run: |
+          docker compose up -d db
+          for i in {1..30}; do
+            STATUS=$(docker inspect --format='{{.State.Health.Status}}' groundwork-db-1 2>/dev/null || echo "starting")
+            if [ "$STATUS" = "healthy" ]; then
+              echo "db is healthy"
+              break
+            fi
+            echo "Waiting for db... ($i/30): $STATUS"
+            sleep 2
+          done
+
+      # The backend entrypoint runs `alembic upgrade head` on container start,
+      # so bringing the backend up exercises the fresh-apply path.
+      - name: Apply migrations from scratch (entrypoint runs alembic upgrade head)
+        run: |
+          docker compose up -d backend
+          sleep 5
+          docker compose ps
+
+      - name: Verify alembic upgrade head is idempotent
+        run: docker compose exec -T backend alembic upgrade head
+
+      - name: Verify alembic downgrade -1 succeeds
+        run: docker compose exec -T backend alembic downgrade -1
+
+      - name: Re-apply latest migration
+        run: docker compose exec -T backend alembic upgrade head
+
+      - name: Tear down compose
+        if: always()
+        run: docker compose down -v

--- a/STATE.md
+++ b/STATE.md
@@ -1,8 +1,8 @@
 # STATE.md — Session Entry Point
 
 **Last updated:** 2026-04-29
-**Active task:** TASK-008B (next)
-**Branch:** task-008-test-infrastructure
+**Active task:** TASK-008A (next — service & router conventions)
+**Branch:** task-008b-ci-pipeline
 
 ---
 
@@ -31,7 +31,7 @@
 | 007 | [Structured logging & PHI exclusion filter](tasks/TASK-007-structured-logging-phi-filter.md) | **Complete** | 001 |
 | 008 | [Test infrastructure & fixtures](tasks/TASK-008-test-infrastructure.md) | **Complete** (per-domain factories deferred) | 001, 002, 003, 007 |
 | 008A | [Service & router layer conventions (shared plumbing only)](tasks/TASK-008A-service-router-conventions.md) | Partial | 002, 003, 004, 006, 007, 008 |
-| 008B | [CI pipeline configuration (GitHub Actions: lint, type check, tests, build)](tasks/TASK-008B-ci-pipeline.md) | Not started | 001, 002, 007, 008, 008C |
+| 008B | [CI pipeline configuration (GitHub Actions: lint, type check, tests, build)](tasks/TASK-008B-ci-pipeline.md) | **Complete** (branch protection is a manual GH setting) | 001, 002, 007, 008, 008C |
 | 008C | [Linter & type-check configuration (ruff + mypy strict in pyproject.toml)](tasks/TASK-008C-linter-config.md) | **Complete** | 001 |
 
 **Partial status notes:**

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,76 @@
+# CI & PR merge requirements
+
+This document describes the CI pipeline that guards every PR to `main`,
+the merge requirements imposed on top of CI, and the manual GitHub
+settings that round out the policy.
+
+Source of truth: SPEC-007 §14.
+
+## Pipeline stages
+
+GitHub Actions runs the following workflows on every PR targeting `main`
+and every push to `main`. All stages run inside Docker containers — no
+Python is installed directly on the runner (SPEC-007 §14.1).
+
+### `ci.yml` — runs on every PR
+
+| Stage | Tool | Fails on |
+|---|---|---|
+| Lint | `ruff check app/ tests/` | Any lint error |
+| Format check | `ruff format --check app/ tests/` | Any unformatted file |
+| Type check | `mypy app/` (strict mode) | Any type error |
+| Backend tests | `pytest` inside the backend container against `db-test` | Any test failure or coverage below 90% |
+| Build | `docker compose build backend` | Build failure |
+
+The coverage threshold (`--cov-fail-under=90`) is enforced by
+`backend/pytest.ini`, not by a separate CI gate (SPEC-007 §14.1).
+
+### `migration-safety.yml` — runs only when `backend/alembic/versions/` changes
+
+Per SPEC-007 §14.3, every PR that touches an Alembic revision must:
+
+- Apply the migration against a fresh database (verify it applies cleanly)
+- Run `alembic upgrade head` against the current schema (verify idempotence)
+- Run `alembic downgrade -1` (verify rollback works)
+- Re-run `alembic upgrade head` to confirm the round-trip is clean
+
+Triggered automatically by a path filter on the workflow.
+
+## PR merge requirements
+
+A PR may only be merged when (SPEC-007 §14.2):
+
+- All CI stages pass (`backend-checks`, `build`, and `migration-safety` if applicable)
+- At least one reviewer has approved
+- The branch is up to date with `main`
+- No unresolved review comments
+
+These rules are enforced by branch protection on `main`, configured
+manually in **GitHub → Settings → Branches → Branch protection rules**.
+
+### Required branch-protection settings
+
+The workflow file cannot configure these — they live in GitHub UI:
+
+- **Require a pull request before merging**
+  - Require approvals: at least 1
+  - Dismiss stale pull request approvals when new commits are pushed
+  - Require review from Code Owners (optional; activate once `CODEOWNERS` exists)
+- **Require status checks to pass before merging**
+  - Require branches to be up to date before merging
+  - Status checks required:
+    - `Lint, type check, tests (backend)`
+    - `Docker image build`
+    - `Apply, upgrade, downgrade` (only if migrations changed — mark as required-when-applicable)
+- **Require conversation resolution before merging**
+- **Do not allow bypassing the above settings** (admins included)
+
+## Out of scope (post-MVP)
+
+These stages are specified in SPEC-007 §14.1 but are not active during
+the MVP because the repository does not yet contain a frontend. They
+activate when a frontend lands:
+
+- Frontend tests (Vitest inside Docker)
+- E2E tests (Playwright inside Docker)
+- Deployment pipeline

--- a/task-logs/TASK-008B-log.md
+++ b/task-logs/TASK-008B-log.md
@@ -1,0 +1,41 @@
+# TASK-008B Log — CI Pipeline Configuration
+
+**Agent:** claude-code
+**Branch:** task-008b-ci-pipeline
+**Date completed:** 2026-04-29
+
+## What Was Done
+
+Added two GitHub Actions workflows and a CI policy document.
+
+1. **`.github/workflows/ci.yml`** — runs on every PR targeting `main` and every push to `main`. Two jobs:
+   - `backend-checks` (lint → format check → type check → tests, in order, all `docker compose exec -T backend ...`).
+   - `build` (`docker compose build backend`), runs in parallel.
+   Concurrency group keyed on `github.ref` cancels superseded runs. Buildx layer cache keyed on `dockerfile` + `pyproject.toml` so reruns reuse the image when neither changed.
+2. **`.github/workflows/migration-safety.yml`** — only runs when a PR/push touches `backend/alembic/versions/**` (workflow-level `paths:` filter, the cleanest way to scope path-based jobs in GHA). Runs apply → upgrade head idempotency check → downgrade -1 → re-apply.
+3. **`docs/ci.md`** — describes the pipeline stages, PR merge requirements (SPEC-007 §14.2), and the manual branch-protection settings that GitHub UI must enforce on top of CI (workflow files cannot configure those themselves).
+
+Final verification on the branch:
+- `docker compose exec backend ruff check app/ tests/` — clean.
+- `docker compose exec backend mypy app/` — Success, no issues in 24 source files.
+- `docker compose exec backend pytest tests/` — 98 passed, coverage 93.62%.
+- Both workflow YAML files parse with `yaml.safe_load` (basic structural sanity check; full validation will come from the first run on GitHub).
+
+## Decisions Made
+
+- **Two workflow files, not one with conditional jobs.** GitHub Actions supports `paths:` filtering only at the workflow level, not the job level. Putting the migration-safety job in its own workflow keeps the path filter declarative; trying to do it inline (e.g. `if: contains(toJSON(github.event.pull_request.changed_files), ...)` ) is fragile because `changed_files` is not a stable field on the event payload.
+- **Format check (`ruff format --check`) included as a separate stage.** Not strictly required by the AC, but it costs nothing on top of an already-running container and prevents unformatted files from ever landing on `main`. Documented in `docs/ci.md`.
+- **`build` runs in parallel with `backend-checks`, not sequentially.** SPEC-007 §14.1 lists stages in order, but does not require sequential execution. Running build in parallel halves wall-clock CI time and the `backend-checks` job rebuilds the image anyway. If they ever diverge (e.g. build needs a multi-arch matrix), splitting them keeps that change isolated.
+- **`docker inspect --format='{{.State.Health.Status}}'` for healthchecks** rather than `docker compose ps --format json`. The compose CLI's JSON format has shifted between versions; `docker inspect` against the explicit container name is stable across compose 2.x.
+- **Branch-protection settings documented, not enforced from code.** GitHub does not expose branch-protection configuration via workflow files; it is a repository setting only the owner can change. Documented in `docs/ci.md` rather than glossed over.
+- **No coverage gate added to CI.** Per AC and SPEC-007 §14.1, `--cov-fail-under=90` lives in `pytest.ini` (TASK-008). CI runs `pytest` and inherits the gate.
+
+## Deviations from Task
+
+- None of substance. The AC's "ordered stages" is interpreted as logical ordering within the `backend-checks` job (lint → format → type → tests). The `build` stage runs as a parallel job; the AC does not require a strict serial dependency.
+
+## Open Items
+
+- **First-run friction expected.** The CI workflow has not yet executed against a real GitHub-hosted runner. Likely friction points: (a) compose `--wait` semantics, (b) container name conventions (`groundwork-backend-1` vs `groundwork_backend_1` depending on compose version), (c) potential Docker Buildx cache-restore quirks. These will surface on the first PR run; iterate as needed.
+- **Branch protection must be enabled in GitHub UI.** Listed in `docs/ci.md` with the exact required settings. Until that is configured, CI failures are advisory rather than blocking.
+- **Required-status-check names need to match what GitHub records.** GitHub's "required status checks" UI will populate the available check names after the first workflow run. Use the names from `docs/ci.md`'s required list.

--- a/tasks/TASK-008B-ci-pipeline.md
+++ b/tasks/TASK-008B-ci-pipeline.md
@@ -1,6 +1,6 @@
 # TASK-008B: CI Pipeline Configuration
 
-**Status:** Not started
+**Status:** Complete (branch protection settings remain a manual GitHub configuration step — documented in `docs/ci.md`)
 **Spec sections:** SPEC-007 §14 (all subsections)
 **ADRs:** —
 **Depends on:** TASK-001 (Docker services), TASK-002 (migrations), TASK-007 (logging), TASK-008 (test fixtures — partial is sufficient), TASK-008C (ruff & mypy config — so lint/type-check stages enforce real rules, not defaults)
@@ -11,17 +11,17 @@ Stand up the CI pipeline **as early as possible** so every PR to `main` is guard
 
 ## Acceptance Criteria
 
-- [ ] GitHub Actions workflow at `.github/workflows/ci.yml` triggers on pull requests targeting `main` and on pushes to `main`
-- [ ] Ordered stages per SPEC-007 §14.1: lint → type check → backend tests → build
-- [ ] Lint stage: `docker compose exec -T backend ruff check app/ tests/` — fails on any lint error
-- [ ] Type check stage: `docker compose exec -T backend mypy app/` — fails on any type error (mypy strict mode per existing config)
-- [ ] Backend test stage: `docker compose exec -T backend pytest` — runs inside the backend container against `db-test`, fails on any test failure
-- [ ] Coverage threshold enforcement is inherited from TASK-008's pytest config (`--cov-fail-under`); CI does not duplicate the gate
-- [ ] Build stage: `docker compose build backend` succeeds
-- [ ] All stages run inside Docker containers — no direct Python install on the CI runner per SPEC-007 §14.1
-- [ ] Alembic migration safety per SPEC-007 §14.3: for any PR touching `backend/alembic/versions/`, CI runs fresh apply → upgrade → downgrade and fails if any step errors
-- [ ] PR merge requirements documented per SPEC-007 §14.2 in `docs/ci.md` (or equivalent): all stages pass, reviewer approval, branch up to date
-- [ ] Branch protection on `main` is documented as a manual GitHub setting (not enforceable from the workflow file itself)
+- [x] GitHub Actions workflow at `.github/workflows/ci.yml` triggers on pull requests targeting `main` and on pushes to `main`
+- [x] Ordered stages per SPEC-007 §14.1: lint → type check → backend tests → build — `backend-checks` job runs lint → format check → mypy → pytest in order; `build` job runs in parallel
+- [x] Lint stage: `docker compose exec -T backend ruff check app/ tests/` — fails on any lint error
+- [x] Type check stage: `docker compose exec -T backend mypy app/` — fails on any type error (mypy strict mode per existing config)
+- [x] Backend test stage: `docker compose exec -T backend pytest` — runs inside the backend container against `db-test`, fails on any test failure
+- [x] Coverage threshold enforcement is inherited from TASK-008's pytest config (`--cov-fail-under`); CI does not duplicate the gate
+- [x] Build stage: `docker compose build backend` succeeds
+- [x] All stages run inside Docker containers — no direct Python install on the CI runner per SPEC-007 §14.1
+- [x] Alembic migration safety per SPEC-007 §14.3: for any PR touching `backend/alembic/versions/`, CI runs fresh apply → upgrade → downgrade and fails if any step errors — `.github/workflows/migration-safety.yml` with a `paths:` filter
+- [x] PR merge requirements documented per SPEC-007 §14.2 in `docs/ci.md` (or equivalent): all stages pass, reviewer approval, branch up to date
+- [x] Branch protection on `main` is documented as a manual GitHub setting (not enforceable from the workflow file itself) — see `docs/ci.md`
 
 ## Files
 


### PR DESCRIPTION
## Summary
- Adds [.github/workflows/ci.yml](.github/workflows/ci.yml) — `backend-checks` (ruff → format check → mypy → pytest, all `docker compose exec`) and `build` (`docker compose build`) jobs on every PR to `main` and every push to `main`. Coverage gate inherited from `pytest.ini`.
- Adds [.github/workflows/migration-safety.yml](.github/workflows/migration-safety.yml) — runs only when a PR touches `backend/alembic/versions/**`. Exercises apply → `upgrade head` idempotency → `downgrade -1` → re-apply per SPEC-007 §14.3.
- Adds [docs/ci.md](docs/ci.md) — pipeline description, PR merge requirements (SPEC-007 §14.2), and the manual branch-protection settings the GitHub UI must apply on top of CI (workflow files cannot configure those themselves).
- Closes [TASK-008B](tasks/TASK-008B-ci-pipeline.md). Log at [task-logs/TASK-008B-log.md](task-logs/TASK-008B-log.md).

## Verification (local)
- `docker compose exec backend ruff check app/ tests/` — clean
- `docker compose exec backend ruff format --check app/ tests/` — 46 files already formatted
- `docker compose exec backend mypy app/` — Success
- `docker compose exec backend pytest tests/` — 98 passed, coverage 93.62%
- Both workflow YAML files parse with `yaml.safe_load`

## Expected first-run friction
First-time CI runs against a real GitHub-hosted runner often surface compose-CLI version quirks. If the workflow fails, likely culprits are container-name conventions or healthcheck-polling output formats — see Open Items in [task-logs/TASK-008B-log.md](task-logs/TASK-008B-log.md).

## After merge
Configure branch protection on `main` per [docs/ci.md](docs/ci.md). Required status checks must include the names GitHub records after the first successful run (`Lint, type check, tests (backend)`, `Docker image build`).

## Test plan
- [ ] First CI run on this PR completes (or surfaces specific issues to iterate on)
- [ ] After merge, configure branch protection per `docs/ci.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)