### PR TITLE
ci: bump checkout to v5 and force Node 24 for remaining JS actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
 
+# Force Node 24 for any JS-based action that hasn't yet shipped a Node 24 release
+# (e.g. docker/setup-buildx-action is still on v3 / Node 20 as of 2026-04).
+# actions/checkout@v5 already runs on Node 24; this env var carries everything else
+# until each action releases its Node 24 update.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 
@@ -21,7 +28,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -92,7 +99,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/migration-safety.yml
+++ b/.github/workflows/migration-safety.yml
@@ -11,6 +11,10 @@ on:
     paths:
       - 'backend/alembic/versions/**'
 
+# See ci.yml for context. docker/setup-buildx-action still ships Node 20.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 
@@ -25,7 +29,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Why
GitHub deprecated Node 20 actions; they will be forced to Node 24 on 2026-06-02 and removed entirely on 2026-09-16.

## Changes
- `actions/checkout@v4` → `actions/checkout@v5` (ships with Node 24 support).
- Add workflow-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to both [ci.yml](.github/workflows/ci.yml) and [migration-safety.yml](.github/workflows/migration-safety.yml). `docker/setup-buildx-action` is still on v3 / Node 20 as of 2026-04; the env var carries it (and any other JS-based action that hasn't shipped a Node 24 release yet).

Drop the env var once each action ships its own Node 24 update.

## Verification
- Both workflow files parse with `yaml.safe_load`.
- No source changes; this is workflow config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)