### PR TITLE
Auth chain decomposition: TASK-014A–J + ADR-010/011/012

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,9 +1,11 @@
 # STATE.md — Session Entry Point
 
-**Last updated:** 2026-05-15
-**Active task:** TASK-011A (next — AttributeValue type casting engine, on the new ADR-009 pattern)
-**Branch:** main
-**Last architectural change:** 2026-05-09 — ADR-009 accepted; ADR-002 amended; Organization (TASK-009) and EntityType / EntityAttribute (TASK-010) refactored to class-per-aggregate Service + Model-as-Entity. AuditLog gained an `outcome` column. The route-level `GroundworkError` handler now writes failure audits in a fresh session. TASK-008A rewritten as the canonical conventions doc; all not-yet-shipped tasks reference ADR-009. **Same-day amendment:** Repository layer removed — each repo was a thin SQL wrapper called from one service; queries now inline in the service file under a `# Query helpers` section. Re-introduce a Repository only when queries are genuinely shared across services (e.g. role-hierarchy walks, JSONB projections).
+**Last updated:** 2026-05-21
+**Active task:** TASK-011A (next — AttributeValue type casting engine, on the new ADR-009 pattern). Auth chain (TASK-014 series) is being designed in parallel on branch `task-014-auth-decomposition`.
+**Branch:** main (auth-chain design work lives on `task-014-auth-decomposition`)
+**Last architectural change:** 2026-05-21 — Auth chain decomposed. ADR-010 (consolidated Auth0 identity architecture: Organizations adopted, universal WebAuthn MFA, 5–15min access tokens + refresh rotation, nonce-only first-login binding, single-connection-per-user for MVP, ServicePrincipal deferred). ADR-011 (invitation lifecycle: PersonRole-at-accept; five-type discriminator; uniform response shape for enumeration mitigation). ADR-012 (`Person.permissions_version` column for zero-staleness permission cache). ADR-008 superseded by ADR-010. TASK-014 decomposed into TASK-014A–014J. Net schema delta for the full auth chain: +1 table (`Invitation`), +1 column (`Person.permissions_version`), +4 seed permissions (`invites.send/revoke/read`, `auth.force_revoke`). All other auth work is Auth0-side configuration or backend code.
+
+**Previous architectural change:** 2026-05-09 — ADR-009 accepted; ADR-002 amended; Organization (TASK-009) and EntityType / EntityAttribute (TASK-010) refactored to class-per-aggregate Service + Model-as-Entity. AuditLog gained an `outcome` column. The route-level `GroundworkError` handler now writes failure audits in a fresh session. TASK-008A rewritten as the canonical conventions doc; all not-yet-shipped tasks reference ADR-009. **Same-day amendment:** Repository layer removed — each repo was a thin SQL wrapper called from one service; queries now inline in the service file under a `# Query helpers` section. Re-introduce a Repository only when queries are genuinely shared across services (e.g. role-hierarchy walks, JSONB projections).
 
 ---
 
@@ -65,10 +67,20 @@
 |---|------|--------|------------|
 | 012 | [Person model & CRUD API](tasks/TASK-012-person-model-and-api.md) | **Complete** (401 test deferred to TASK-014) | 004, 009, 006, 008 |
 | 013 | [RBAC models & seed data](tasks/TASK-013-rbac-models-and-seed-data.md) | **Complete** (hierarchy invariant not enforced at model level — seed data conforms; revisit in TASK-016) | 009, 012 |
-| 014 | [Auth middleware — JWT, person resolution, org context](tasks/TASK-014-auth-middleware.md) | Not started | 012, 013 |
+| 014 | [Auth middleware — JWT, person resolution, org context, `Person.permissions_version` migration](tasks/TASK-014-auth-middleware.md) | Not started | 012, 013, 014A |
+| ↳ 014A | [Consolidated ADR ratification & SPEC-007 edits (ADR-010)](tasks/TASK-014A-auth-consolidated-adr.md) | Not started | — |
+| ↳ 014B | [Auth0 tenant configuration & env doc](tasks/TASK-014B-auth0-tenant-configuration.md) | Not started | 014A |
+| ↳ 014C | [Post-Login Actions & `is_active` mirroring](tasks/TASK-014C-post-login-actions.md) | Not started | 014B |
+| ↳ 014D | [Auth0 Management API integration](tasks/TASK-014D-auth0-management-api.md) | Not started | 014B |
+| ↳ 014E | [Bootstrap first admin (one-shot deploy-token endpoint)](tasks/TASK-014E-bootstrap-first-admin.md) | Not started | 014D |
+| ↳ 014F | [Invitation resource (CRUD, state machine, the one new table)](tasks/TASK-014F-invitation-resource.md) | Not started | 014D |
+| ↳ 014G | [Invitation accept + nonce binding](tasks/TASK-014G-invitation-accept-binding.md) | Not started | 014F |
+| ↳ 014H | [Service caller identity — DEFERRED](tasks/TASK-014H-service-caller-identity-deferred.md) | Deferred (post-MVP) | (TBD when reactivated) |
+| ↳ 014I | [Permission cache invalidation strategy](tasks/TASK-014I-permission-cache-invalidation.md) | Not started | 014, 015 |
+| ↳ 014J | [Force-revoke operator endpoint](tasks/TASK-014J-force-revoke.md) | Not started | 014C, 014D, 014I |
 | 015 | [Permission resolution, caching, & row-level filtering](tasks/TASK-015-permission-resolution-and-caching.md) | Not started | 013, 014 |
-| 016 | [Role & permission management API](tasks/TASK-016-role-permission-management-api.md) | Not started | 013, 015 |
-| 017 | [Person role assignment API](tasks/TASK-017-person-role-assignment-api.md) | Not started | 012, 013, 015 |
+| 016 | [Role & permission management API (adds invites.* + auth.force_revoke seeds; permissions_version write discipline)](tasks/TASK-016-role-permission-management-api.md) | Not started | 013, 015 |
+| 017 | [Person role assignment API (permissions_version write discipline)](tasks/TASK-017-person-role-assignment-api.md) | Not started | 012, 013, 015 |
 | 018 | [Auth self-inspection endpoints](tasks/TASK-018-auth-self-inspection.md) | Not started | 014, 015 |
 | 019 | [Auto-permission generation on EntityType creation](tasks/TASK-019-auto-permission-generation.md) | Not started | 010, 013 |
 

--- a/adrs/ADR-010-consolidated-auth-architecture.md
+++ b/adrs/ADR-010-consolidated-auth-architecture.md
@@ -1,0 +1,126 @@
+# ADR-010 — Consolidated Auth0 identity architecture
+
+**Date:** 2026-05-21
+**Author:** claude-code
+**Status:** Proposed (supersedes ADR-008 when accepted)
+
+## Context
+
+TASK-014 was scoped as "JWT validation middleware" with the assumption that an Auth0-issued token would arrive containing a `sub` claim that maps to a `Person.auth_subject`. Several decisions are implicit in that scope and need to be ratified before TASK-014 ships, because the JWT shape and the surrounding identity ceremony are load-bearing for everything downstream.
+
+The implicit decisions:
+
+- Whether Auth0 Organizations are adopted (org-bound JWTs vs tenant-agnostic JWTs with header scope).
+- How users sign up and bind to a `Person` row (self-service vs invite-only; if invited, how `auth_subject` gets written).
+- What MFA policy applies and which factors are acceptable for a HIPAA-bound clinical product.
+- How access-token TTL is balanced against revocation latency.
+- Whether multiple authentication connections (email/password, Google SSO, Microsoft SSO) can attach to the same user.
+- Whether non-human callers (cron jobs, integrations, M2M services) get their own identity model now or later.
+
+Leaving these as implementation-time decisions inside TASK-014 risks producing a system that is HIPAA-defensible only by accident. ADR-008 (Proposed) acknowledged the request-context part of this gap but parked it under a temporary stub seed. This ADR resolves it.
+
+## Decision
+
+The following six positions are adopted together. They are coupled in the sense that each one assumes the others; partial adoption produces an inconsistent JWT shape and a more complex middleware.
+
+### 1. Auth0 Organizations: adopted
+
+Every authenticated request carries an Auth0-issued JWT with an `org_id` claim that identifies the application `Organization` the token is scoped to. A token issued for org_1 is not valid against org_2 — the middleware rejects mismatched scope at the JWT layer, before any database read.
+
+The application `Organization.id` remains the only tenant key used by domain FKs, audit logs, and RLS. Auth0's organization IDs are external identity IDs mapped to application organizations through `organizations.auth_provider_org_id` (nullable) per ADR-008's existing direction.
+
+Consequence: org-switching is a fresh login against the target org, not a mid-session header swap. A clinician with roles in two practices acquires two distinct tokens, never one fungible token.
+
+### 2. MFA: universal, WebAuthn/passkeys preferred
+
+MFA is required for every authenticated user. No opt-out tier. Preferred factor is WebAuthn (passkeys, security keys); TOTP and SMS remain available as fallbacks but are not the default enrollment path. Enforcement happens inside an Auth0 Post-Login Action that fails closed when MFA has not been completed for the current session.
+
+### 3. Token TTL: 5–15 minute access tokens with refresh rotation
+
+Access tokens carry a 5–15 minute TTL. Refresh tokens use rotation with reuse/breach detection (Auth0's native feature): each refresh issues a new RT and invalidates the prior; parallel use of the same RT invalidates the entire family. No backend-maintained revocation list.
+
+The 15-minute upper bound on access-token TTL is the worst-case staleness window for `Person.is_active = false` propagation. That window is acceptable for routine deactivation; immediate revocation after a security event uses the force-kill operator endpoint (TASK-014J), which calls Auth0 Management API to terminate sessions and refresh families.
+
+### 4. First-login binding: nonce-only, never by email
+
+Application Persons are bound to Auth0 `sub` claims exclusively through invitation-acceptance nonces:
+
+1. An admin creates an `Invitation` row with a unique single-use nonce.
+2. Auth0 emails the invitee using its own organization-invitation primitives.
+3. After Auth0 signup, the frontend posts `{nonce, jwt}` to `POST /api/v1/invitations/accept`.
+4. The backend resolves the invitation by nonce, validates state and TTL, writes `Person.auth_subject = JWT.sub`, creates the planned `PersonRole`, and transitions the invitation to `accepted`.
+
+No email lookup, ever. There is no code path on the backend that resolves an Auth0 user to a `Person` via email matching. This eliminates the cross-tenant enumeration vector (an admin cannot probe whether an email already exists in another tenant) and gives every binding a tamper-evident, single-use token.
+
+The full invitation lifecycle is detailed in ADR-011.
+
+### 5. Auth0 `sub` stability: single connection per user (MVP)
+
+Every Auth0 user belongs to exactly one connection (email/password + WebAuthn passkey for MVP). Users cannot link a Google or Microsoft identity to an existing account. New signups go through the configured connection.
+
+Account-linking — Auth0's primary-user / secondary-user model that allows multiple identity providers to attach to one logical user — is the documented upgrade path when SSO becomes a customer requirement. It is not in MVP. Multiple `Principal` rows per human is explicitly rejected as a path forward.
+
+Roadmap note: practices wanting Google Workspace or Microsoft 365 SSO at sign-up cannot have it under this decision. If early customer conversations surface SSO as a hard requirement, a follow-up ADR moves account-linking into scope.
+
+### 6. Service caller identity: deferred
+
+MVP has no inbound machine-to-machine callers. Webhook receivers (Stripe, etc., when they exist) authenticate by shared-secret signature, not JWT. Outbound integrations (insurance eligibility, reminders) run *as* the backend itself. Scheduled work (consent expiry sweep per ADR-006) is invoked as an authenticated admin HTTP request, with the operator as audit actor — no service identity is involved.
+
+Consequently, MVP introduces no `ServicePrincipal` table, no `Principal` parent abstraction, and no `actor_type` enum on `AuditLog`. `Person.auth_subject` stays where it is. `AuditLog.actor_person_id` remains nullable, with `null` meaning system-triggered per existing SPEC-006 design.
+
+When the first real inbound M2M caller appears post-MVP, the migration path is:
+
+1. Add a `ServicePrincipal` table with direct `ServicePrincipalPermission` grants (OAuth-scope pattern, no role layer).
+2. Add an `actor_service_principal_id` FK to `AuditLog` and an `actor_type` enum; default existing rows to `'human'`.
+3. Branch the middleware on JWT claim shape: tokens with no user `sub` (M2M tokens have `gty=client-credentials` and no user identity) resolve to a `ServicePrincipal`.
+
+This is straightforward additive work. Introducing the abstraction now, before any caller exists, would be speculative design.
+
+## Consequences
+
+**For:**
+
+- The JWT shape is fully specified before TASK-014 writes a line of code. Downstream tasks (014C–J, 015–019) compose against a stable contract.
+- Stolen access tokens are bounded to one org for at most 15 minutes. Refresh token theft is detected and family-revoked by Auth0 natively.
+- Tenant isolation has two layers: the JWT's `org_id` claim (issuance-time) and Postgres RLS keyed on `app.org_id` (query-time). Either layer alone would be insufficient; together they are HIPAA-defensible.
+- The seam between Auth0 identity and our `Person` model is single-purpose: invitation-accept writes `auth_subject`, every other login resolves by `auth_subject`. There is no email-matching backdoor.
+- MVP schema delta is minimal: one new table (`Invitation`, per ADR-011), one new column (`Person.permissions_version`, per ADR-012), four seed permission rows. No Principal abstraction.
+
+**Against:**
+
+- Practices wanting SSO from day one are not supported; the account-linking upgrade is post-MVP work.
+- The 15-minute access-token TTL means routine deactivation propagation has a 15-minute worst-case window. For incident response, this is mitigated by the TASK-014J force-kill endpoint, but operators must remember the procedure exists.
+- Org-switching as a fresh login is a worse UX than header-swap for clinicians who work across multiple practices. The security gain (bounded stolen-token blast radius) is judged to be worth the friction.
+- A future M2M caller will require a schema migration to introduce `ServicePrincipal` and `actor_type`. The migration is additive and bounded, but it is migration work.
+
+## Alternatives considered
+
+**Tenant-agnostic JWT with `X-Organization-Id` header.** Earlier-drafted approach. Cheaper to implement (no Auth0 Orgs setup), but a stolen token is valid against every org the bearer has a role in. Rejected on security grounds.
+
+**Backend-driven invitations using Auth0 Management API tickets.** A backend-controlled flow that creates the Auth0 user, generates a password-change ticket, sends the email itself. Works regardless of whether Auth0 Organizations are adopted. Rejected as the primary path because Auth0 Organizations' native invitation flow handles email delivery, TTL, and ticket lifecycle for free, and the org-scoping property makes it the natural fit.
+
+**Email-fallback binding (try `sub`, then email).** Would let users sign up via Auth0 Universal Login without an invitation, then bind to an existing Person row by email match. Rejected: leaks cross-tenant existence and creates a path where any Auth0 user with a known email can bind to a Person they should not have access to.
+
+**`Principal` abstraction with `HumanPrincipal` / `ServicePrincipal` variants in MVP.** Earlier-drafted approach. Adds four tables (`Principal`, `HumanPrincipal`, `ServicePrincipal`, `ServicePrincipalPermission`) and a polymorphic `actor_type` enum on `AuditLog`. Rejected for MVP: no inbound M2M callers exist; the abstraction solves a problem we do not have. Migration path is documented above for when the problem appears.
+
+**Long-lived access tokens (1+ hour) with backend revocation list.** Simpler refresh story, but requires us to maintain a revocation list and consult it per request — adding a database hit per auth check and a new failure mode (revocation list unavailable → fail-open or fail-closed?). Rejected: short TTLs + RT rotation gives equivalent security with no backend state.
+
+## Phased plan
+
+- [ ] Epic 1: Update SPEC-007 §3 (auth flow) to reference Auth0 Organizations and the nonce-binding model. Mark ADR-008 superseded.
+- [ ] Epic 2: TASK-014A acceptance criteria reference this ADR as the foundational contract.
+- [ ] Epic 3: TASK-014B (Auth0 tenant configuration) implements the Auth0-side configuration this ADR mandates (Organizations enabled, universal MFA policy, RT rotation + breach detection, single-connection setup).
+- [ ] Epic 4: TASK-014 (JWT middleware) implements the JWT contract this ADR defines (validate `sub` + `org_id`, resolve `Person`, check active `PersonRole`, set `app.org_id`).
+- [ ] Epic 5: When the first inbound M2M caller is proposed, draft a follow-up ADR for the `ServicePrincipal` introduction; do not introduce the abstraction speculatively.
+
+## References
+
+- ADR-002 — no `relationship()`; FK-only with explicit joins.
+- ADR-006 — consent expiry sweep endpoint; system-triggered invocation model.
+- ADR-008 — request-context and auth-provider org boundary (superseded by this ADR).
+- ADR-009 — service + model-as-entity layering; the architecture this ADR's middleware composes against.
+- ADR-011 — invitation lifecycle and PersonRole post-accept (this ADR's binding mechanism is detailed there).
+- ADR-012 — permission cache invalidation strategy (this ADR's permission resolution layer).
+- SPEC-002 §3, §4, §5 — identity and RBAC model; auth subject rule, soft delete rule.
+- SPEC-006 §3 — `AuditLog.actor_person_id` null semantics for system-triggered events.
+- SPEC-007 §3 — authentication and organization context.

--- a/adrs/ADR-011-invitation-lifecycle.md
+++ b/adrs/ADR-011-invitation-lifecycle.md
@@ -1,0 +1,161 @@
+# ADR-011 — Invitation lifecycle and PersonRole post-accept
+
+**Date:** 2026-05-21
+**Author:** claude-code
+**Status:** Proposed
+
+## Context
+
+ADR-010 ratifies that `Person.auth_subject` is bound exclusively through invitation acceptance — there is no email-matching fallback, no self-service signup path. That ratification leaves the invitation resource itself unspecified: what its shape is, what states it transitions through, when `PersonRole` is created, and how the five distinct invite types share an endpoint without becoming a tangle of conditionals.
+
+Several sub-decisions cluster here:
+
+- Whether `PersonRole` is created when the invite is sent (with a "pending" status column) or only when the invite is accepted (no pending state on PersonRole).
+- Whether email and role are inferred from existing `Person` rows or always carried on the invite itself.
+- How the cross-org existing-Person case (type 4) differs from new-Person invites in side effects.
+- What the audit log records at each transition.
+- How response shapes prevent cross-tenant email enumeration.
+
+Resolving these as a single design is cheaper than handling each at implementation time, because PersonRole's state shape and Invitation's state machine are coupled.
+
+## Decision
+
+### Invitation as a first-class resource
+
+`Invitation` is a new table backing `POST /api/v1/invitations` and the surrounding CRUD endpoints. It is scoped to one `Organization` (the `organization_id` is stamped from the request context, never from the body). The row carries the *planned* identity changes that will land on accept, plus a single-use nonce that is the only binding key.
+
+Schema (load-bearing fields only):
+
+- `id` — UUID PK
+- `organization_id` — FK, NOT NULL, set from request context
+- `type` — enum `('provider', 'admin', 'system_admin', 'cross_org')`
+- `email` — NOT NULL (used by Auth0 to send the invite; never by our backend to resolve a Person)
+- `first_name`, `last_name` — nullable, populated for types 1–3, null for type 4
+- `planned_role_slug` — NOT NULL, the role to grant on accept
+- `planned_entity_instance_id` — nullable; required when the role's `primary_domain` maps to a person_subtype EntityType (see SPEC-002 §2)
+- `planned_entity_instance_payload` — JSONB nullable; if set, an `EntityInstance` is created on accept from this payload
+- `nonce` — opaque single-use string, indexed unique
+- `state` — enum `('pending', 'accepted', 'expired', 'revoked')`
+- `auth0_invitation_id` — nullable; populated after Auth0's invitation API is called (for revocation cleanup)
+- `created_by_person_id` — NOT NULL (FK to Person; the inviter)
+- `created_at`, `accepted_at`, `expired_at`, `revoked_at` — timestamps
+- `expires_at` — NOT NULL; aligned to Auth0's invitation TTL
+
+A partial unique index `(organization_id, email) WHERE state = 'pending'` prevents two pending invites for the same email in the same org. Revoked and expired rows are historical and do not conflict with new sends.
+
+### State machine
+
+```
+pending → accepted    (nonce posted, Person + PersonRole written, terminal)
+pending → expired     (TTL hit, terminal)
+pending → revoked     (admin canceled, terminal)
+```
+
+All transitions write an `AuditLog` row. `accepted` is immutable. The invitation may not be resurrected from `expired` or `revoked` — a new invitation row is created instead (the partial unique index on pending rows does not conflict with the historical row).
+
+### PersonRole is created at accept, never at send
+
+The Invitation row carries the *planned* `PersonRole` shape (`planned_role_slug`, `planned_entity_instance_id`, `planned_entity_instance_payload`). No `PersonRole` row exists until the accept transition fires. Inside the accept transaction:
+
+1. Resolve the invitation by nonce; verify `state = 'pending'` and `now() < expires_at`.
+2. For new-Person invites (types 1–3): create the `Person` row with `auth_subject = JWT.sub`. For cross-org invites (type 4): confirm a `Person` with matching `auth_subject` already exists and reuse it.
+3. For provider invites (type 1): create the `EntityInstance` from `planned_entity_instance_payload` (or verify `planned_entity_instance_id` exists and matches the role's domain).
+4. Create the `PersonRole(person_id, role_slug, organization_id, entity_instance_id)`.
+5. Transition the invitation: `state = 'accepted'`, `accepted_at = now()`.
+6. Increment `Person.permissions_version` (per ADR-012) so any cached permissions for the new Person are invalidated.
+7. Write `AuditLog` row: `action = 'invitation.accepted'`, `actor_person_id = newly-bound Person`, `previous_state = pending`, `next_state = accepted`.
+
+The whole sequence is one transaction. Partial failure rolls back; the invitation stays `pending` and can be retried (until TTL).
+
+### Why PersonRole-at-accept rather than at-send
+
+Two designs were considered:
+
+- **Option 1 (chosen):** PersonRole exists only after accept. Invitation carries the planned role; commit happens at accept. `PersonRole.revoked_at IS NULL` continues to mean "active" — no third state.
+- **Option 2:** PersonRole created at invite send with a new `accepted_at` (nullable) column. Active grants require both `revoked_at IS NULL` and `accepted_at IS NOT NULL`.
+
+Option 1 is chosen because Option 2 requires every permission resolution query in TASK-015, every PersonRole listing in TASK-017, and every reporting query downstream to filter on `accepted_at IS NOT NULL` in addition to `revoked_at IS NULL`. One forgotten filter and a pending-but-not-accepted PersonRole leaks effective permissions. Option 1 makes the rule simpler ("active" = `revoked_at IS NULL`) and removes a class of mistake.
+
+The cost of Option 1 is that the invitation row carries duplicate role/instance data (planned vs eventual). That cost is bounded: the invitation row is short-lived (7 days TTL) and the duplication is read-only once accepted.
+
+### Five invite types, one endpoint
+
+`POST /api/v1/invitations` discriminates on the `type` field. The five types are documented in `auth0-design-notes.md` §3 and reproduced in TASK-014F's acceptance criteria. Key points:
+
+- **Type 1 (provider)** — requires `planned_entity_instance_payload` or `planned_entity_instance_id`. Creates Person + Auth0 user + EntityInstance + PersonRole on accept.
+- **Type 2 (admin)** — no entity_instance. Creates Person + Auth0 user + PersonRole on accept.
+- **Type 3 (system_admin)** — same as admin but role is platform-scoped (no `organization_id` on PersonRole). Callable only by an existing `system_admin`.
+- **Type 4 (cross_org)** — existing `Person` with `auth_subject` already set. Creates only PersonRole on accept. Before sending the Auth0 invitation, the backend calls Auth0 Management API to add the existing Auth0 user as a member of the target Auth0 Organization (Auth0 will not issue an org-scoped JWT until membership exists).
+- **Type 5 (bootstrap)** — exists outside the `/invitations` endpoint. See `POST /api/v1/system/bootstrap` (TASK-014E); gated by a one-shot deploy token, not by an authenticated invitation flow.
+
+### Uniform response shape (enumeration mitigation)
+
+Every successful `POST /api/v1/invitations` response returns the same envelope:
+
+```json
+{ "status": "pending", "invitation_id": "<uuid>" }
+```
+
+regardless of whether the target email maps to an existing `Person` in another tenant, was newly provisioned, or was a cross-org reactivation. The sender cannot distinguish the cases. Differentiating logic lives entirely on the accept path (where the actor is the invitee themselves, not the inviter).
+
+This is a load-bearing privacy property for a HIPAA-bound platform: an admin must not be able to probe whether a clinician works at a competing practice by typing their email into the invite form.
+
+### Resend rotates the nonce
+
+`POST /api/v1/invitations/{id}/resend` is permitted only when `state = 'pending'`. The action:
+
+1. Generates a new nonce.
+2. Calls Auth0 Management API to revoke the existing Auth0 invitation and create a new one (so the old email link is dead).
+3. Updates `expires_at` to a fresh TTL from now.
+4. Writes an `AuditLog` row.
+
+The old nonce is unrecoverable. Anyone holding the old email link gets a 410 Gone from `POST /invitations/accept`.
+
+### Revoke is non-destructive
+
+`DELETE /api/v1/invitations/{id}` sets `state = 'revoked'` and `revoked_at = now()`. The row is preserved for audit. The Auth0 invitation is revoked via Management API. The partial unique index on `(organization_id, email) WHERE state = 'pending'` allows a fresh invitation to be sent immediately.
+
+## Consequences
+
+**For:**
+
+- Permission queries downstream of this ADR have one rule for "active grant": `revoked_at IS NULL`. No "pending invite" hidden state.
+- Cross-tenant enumeration is closed at the response-shape layer, not by convention.
+- The nonce binding is single-use, single-purpose, and impossible to confuse with email lookup.
+- Type 4 (cross-org existing Person) shares the same endpoint shape as other invites, so the invitation resource is uniform. The type-specific work happens behind the API.
+- Bootstrap (type 5) lives at a separate endpoint with a different auth model (deploy token, not JWT), so the `/invitations` endpoint never has to consider unauthenticated callers.
+
+**Against:**
+
+- Invitation rows carry duplicated identity data (planned vs eventual). This is acceptable because invitations are short-lived (7-day TTL).
+- The accept transaction does six things in sequence (resolve, create-Person, create-EntityInstance, create-PersonRole, transition-invitation, audit) plus the `permissions_version` increment. It must be transactional; partial commit produces an unusable Person row.
+- Type 4 (cross-org) requires the backend to call Auth0 Management API twice (add-to-Org, then create-invitation) on the send path. Missing the first step produces an invitation that delivers a token without the target org scope.
+
+## Alternatives considered
+
+**PersonRole created at invite send with `accepted_at` column (Option 2 above).** Already covered. Rejected because every downstream permission query becomes a two-filter query, and one forgotten filter leaks permissions.
+
+**Auth0-driven invitation only, no application Invitation table.** Use Auth0's invitation primitives end-to-end; backend reads invitation state from Auth0. Rejected: application-level state (planned role, planned entity_instance, audit trail) has nowhere to live, and querying Auth0 per request to resolve an in-flight invitation is operationally fragile.
+
+**Multiple type-specific endpoints (`POST /invitations/provider`, `/invitations/admin`, etc.).** Each endpoint validates its own payload shape. Rejected as ceremony: the four types share more than they differ, and the discriminator-on-`type` pattern is well-established. The complexity that the multiple-endpoints option would push out is real but lives at the validator layer, where it belongs.
+
+**Allow `Person.auth_subject` rebinding via invitation.** Would let an invitation overwrite `auth_subject` if the Person already had one. Rejected: makes the invitation a credential-takeover vector. Cross-org invites (type 4) confirm the existing `auth_subject` matches the JWT's `sub`; they do not write a new one.
+
+## Phased plan
+
+- [ ] Epic 1: TASK-014F (Invitation resource) implements the table, CRUD endpoints, and state machine.
+- [ ] Epic 2: TASK-014G (accept binding) implements the accept transaction in full.
+- [ ] Epic 3: TASK-016 seed catalog migration adds `invites.send`, `invites.revoke`, `invites.read` permissions.
+- [ ] Epic 4: TASK-017 acceptance criteria explicitly note that PersonRole creation via invite-accept is a separate code path from `POST /people/{id}/roles` direct assignment, and both must increment `permissions_version`.
+- [ ] Epic 5: SPEC-007 §8.1 endpoint inventory updated with the `/invitations` endpoints.
+
+## References
+
+- ADR-002 — FK-only with explicit joins.
+- ADR-003 — partial unique indexes for revocable records (the `WHERE state = 'pending'` index follows this pattern).
+- ADR-009 — service + model-as-entity; the `Invitation` model lives as one aggregate under that pattern.
+- ADR-010 — consolidated auth architecture; this ADR is its binding-mechanism detail.
+- ADR-012 — permission cache invalidation; the accept transaction's `permissions_version` increment is defined there.
+- SPEC-002 §2 — `PersonRole` and `entity_instance_id` rules.
+- SPEC-002 §4 — auth subject rule, assignment integrity rule.
+- SPEC-006 §3, §7 — `AuditLog` semantics, audit atomicity requirement.

--- a/adrs/ADR-012-permission-cache-invalidation.md
+++ b/adrs/ADR-012-permission-cache-invalidation.md
@@ -1,0 +1,125 @@
+# ADR-012 — Permission cache invalidation via Person.permissions_version
+
+**Date:** 2026-05-21
+**Author:** claude-code
+**Status:** Proposed
+
+## Context
+
+TASK-015 designs an in-process TTL cache for the effective permission set per `(person_id, organization_id)`, with a 60-second TTL per SPEC-007 §3.3. The cache solves the read amplification of role-hierarchy walks: every authenticated request would otherwise re-walk the parent_role_id chain and re-union RolePermission grants. With caching, the walk happens at most once per minute per (person, org).
+
+The TTL alone has a HIPAA-relevant gap: when a `PersonRole` is revoked — clinician terminated, role downgraded, grant rescinded — the cached effective permissions for that person continue to grant access for up to 60 seconds. In a multi-worker uvicorn or gunicorn deployment, "same process" invalidation (which TASK-015's draft mentions) does not propagate to other workers, so the effective staleness window is the full TTL across the fleet.
+
+For routine permission changes that is acceptable. For revocation tied to a security event — fired clinician, suspected credential compromise — even 60 seconds of continued access is a documented audit finding. The cache invalidation strategy must reduce that window to zero for any state-changing operation that the system itself knows about.
+
+Three approaches were considered:
+
+1. **Short TTL only**, accepting the staleness window. Simplest. Worst staleness.
+2. **Postgres `LISTEN`/`NOTIFY`** to broadcast invalidation events across workers.
+3. **Per-Person generation column** (`permissions_version`) that the resolver reads on every cache lookup, comparing against the cached value.
+
+LISTEN/NOTIFY is technically attractive — explicit invalidation, low latency, no application-side coordination beyond subscribing. In practice, it has two failure modes that are uncomfortable for a HIPAA-bound platform:
+
+- It requires persistent sessions to be useful. With PgBouncer in transaction-pooling mode (the default for FastAPI deployments and the configuration this codebase plans to use), session-level state including `LISTEN` subscriptions does not survive between transactions. Moving the listener connection to session mode means special-casing one connection out of the pool, which is operationally fragile.
+- Notifications can be missed during reconnection. If a worker's listener connection drops and reconnects, any `NOTIFY` fired during the gap is lost. There is no replay. The application would need a fallback (e.g., periodic full cache flush) to bound the gap — at which point the explicit-invalidation property is no longer reliable.
+
+The generation-column approach trades one extra indexed PK read per request for zero-staleness correctness, with no inter-process coordination. The read cost is sub-millisecond and well-bounded; the operational profile is plain SQL, no special pooling, no listener lifecycle to manage.
+
+## Decision
+
+### `Person.permissions_version` column
+
+Add an integer column to `Person`:
+
+```sql
+ALTER TABLE person ADD COLUMN permissions_version INTEGER NOT NULL DEFAULT 0;
+```
+
+The migration is bundled with TASK-014 (the JWT middleware task) as part of the foundational auth chain.
+
+### Cache key shape
+
+The TASK-015 in-process cache keys on `(person_id, organization_id, permissions_version)`. The cached value is the effective permission set for that triple. On read:
+
+1. Resolver loads the current `Person.permissions_version` via a single indexed PK lookup.
+2. Build the cache key with the current version.
+3. If a value exists for that key and is within the 60-second TTL, return it (cache hit).
+4. Otherwise, perform the four-step resolution from SPEC-002 §5, store under the new key, return the result (cache miss + reload).
+
+Cache entries keyed on stale versions become unreachable as soon as the version is incremented. They expire from memory naturally via the 60-second TTL ceiling.
+
+### Write discipline
+
+Every database mutation that could change a Person's effective permission set must increment `permissions_version` for the affected Person in the same transaction as the mutation:
+
+- `PersonRole` insert (assignment): increment for the assigned Person.
+- `PersonRole` update setting `revoked_at` (revocation): increment for the affected Person.
+- `RolePermission` insert/update (grant or revoke at role level): increment `permissions_version` for *every Person currently holding that role*. This is a wider write but it is the correct semantic — the role's effective grants changed for every holder.
+- `Role` update that changes `parent_role_id` (hierarchy edit): increment for every Person holding any role whose hierarchy walk includes the modified role.
+- TASK-014J force-kill: increment for the targeted Person as part of the force-revoke transaction.
+
+This write discipline lives in the service-method layer for TASK-016 (role and permission management), TASK-017 (PersonRole assignment), and TASK-014J. Each task's acceptance criteria reference this ADR.
+
+### Staleness window: zero (for tracked changes)
+
+For any database state change that the application knows about, the cache is correct on the very next request after the mutating transaction commits. The version check on read happens before the cache lookup, so a stale cached entry is structurally unreachable.
+
+The 60-second TTL remains as a memory ceiling: cache entries keyed on old versions are eventually evicted, bounding the in-process cache size to roughly `live_persons * max_orgs_per_person` entries. The TTL is not the staleness window.
+
+### Granularity: per-Person, not per-(Person, organization)
+
+`permissions_version` is a single integer per `Person`, not a row per `(person_id, organization_id)` pair. Consequence: revoking a `PersonRole` in org_1 invalidates the cache for that Person's org_2 access too — even though org_2's grants did not change.
+
+Cost: one extra cache reload on the next org_2 request after an org_1 mutation. For a Person who mostly works in one organization at a time, this is invisible. For a Person who holds active roles in many organizations simultaneously and switches between them rapidly, every grant change in any org evicts the cache for all of them.
+
+This tradeoff is accepted for MVP. If profiling later shows it matters, the escape hatch is to move `permissions_version` into a separate `(person_id, organization_id)` table — same algorithm, finer grain, no call-site changes outside the resolver and the increment logic.
+
+### Per-request cost
+
+Every authenticated request that does a permission check pays one extra indexed PK read on `Person.permissions_version`. With a PK index in shared buffers, this is sub-millisecond and well within the request budget. The alternative (LISTEN/NOTIFY) is zero-cost on hit but unbounded-cost on the reconnect-and-replay path; the constant-cost-per-request approach is preferred for predictability.
+
+## Consequences
+
+**For:**
+
+- HIPAA-relevant permission revocations propagate within one request. The 60-second TTL is no longer a security-relevant staleness window.
+- The strategy is multi-worker safe by construction. No inter-process coordination is needed — every worker reads the authoritative version from the database.
+- PgBouncer-compatible in transaction-pooling mode. No special connection lifecycle.
+- The cache key shape is explicit and self-documenting: `(person_id, organization_id, permissions_version)`. Any code review that sees a cache key with fewer components knows to look harder.
+
+**Against:**
+
+- One extra indexed PK read per authenticated request. Sub-millisecond but non-zero. For most workloads invisible; for an extreme high-RPS endpoint with deep permission gating it would be measurable.
+- The per-Person granularity invalidates cross-org cache entries. Acceptable for MVP; an escape hatch exists.
+- The write discipline is dispersed across multiple service methods (TASK-015, 016, 017, 014J). Forgetting to increment in a new code path produces silent cache staleness on hot paths — exactly the failure mode the cache version is supposed to prevent. Each task's acceptance criteria must explicitly require the increment.
+- The `permissions_version` increment for `RolePermission` and `Role` hierarchy changes can touch many Person rows. For seed catalog edits this is unobjectionable; for routine role-permission grants it is a small additional write per Person holding the role.
+
+## Alternatives considered
+
+**Short TTL only (60 seconds, no version check).** Simplest. Rejected: permission revocation has a 60-second worst-case window across the fleet, which is a HIPAA audit concern.
+
+**Postgres `LISTEN`/`NOTIFY` for cross-worker invalidation.** Discussed in Context. Rejected: PgBouncer transaction-pooling incompatibility, lost-notification edge cases under reconnect, requires fallback cache flush which undermines the explicit-invalidation property.
+
+**Redis pub/sub for cross-worker invalidation.** Adds a Redis dependency to the stack. Rejected: Redis is not currently on the stack, and adding infrastructure to solve a problem the database can solve adequately is over-engineering.
+
+**Per-(Person, organization) generation table.** Finer-grained invalidation; cross-org changes don't invalidate other orgs. Rejected for MVP because the cost of the per-Person granularity is acceptable and the migration to per-(Person, organization) is straightforward if needed later.
+
+**Immediate cache eviction on every write via in-process event bus.** Each worker subscribes to a process-local event bus that mutators publish to. Rejected: solves the same-process case but not the multi-worker case, which is the actual failure mode.
+
+## Phased plan
+
+- [ ] Epic 1: TASK-014 adds the `permissions_version` column migration alongside its middleware work.
+- [ ] Epic 2: TASK-015's cache implementation keys on the four-component tuple including `permissions_version`; resolver reads the current version on every cache lookup.
+- [ ] Epic 3: TASK-016 acceptance criteria require `permissions_version` increment on every `RolePermission` grant/revoke and every `Role` hierarchy update affecting holders.
+- [ ] Epic 4: TASK-017 acceptance criteria require `permissions_version` increment on every `PersonRole` assignment and revocation.
+- [ ] Epic 5: TASK-014J (force-kill) increments `permissions_version` as part of its revoke transaction (step 3 of the documented flow).
+- [ ] Epic 6: TASK-014I documents this strategy in the task file and ships any cache-implementation code that doesn't already exist after TASK-015.
+
+## References
+
+- ADR-009 — service + model-as-entity layering. The increment lives in service-method code per ADR-009's conventions.
+- ADR-010 — consolidated auth architecture; this ADR is its permission-resolution layer.
+- ADR-011 — invitation lifecycle; the accept transaction's `permissions_version` increment is part of this strategy.
+- SPEC-002 §5 — four-step authorization resolution model.
+- SPEC-002 §4 — revocation rule (active grants require `revoked_at IS NULL`).
+- SPEC-007 §3.3 — permission resolution and caching contract.

--- a/specs/SPEC-002-identity-and-rbac.md
+++ b/specs/SPEC-002-identity-and-rbac.md
@@ -207,6 +207,10 @@ On platform initialization, the system seeds baseline roles, permissions, and ro
 | audit.read | audit | read | Query the audit log. |
 | tenants.manage | tenants | manage | Create, suspend, or update tenant organizations. |
 | system.configure | system | manage | Platform-level operational configuration. |
+| invites.send | invites | send | Create and resend invitations for new Persons or new PersonRole assignments (per ADR-011). |
+| invites.revoke | invites | revoke | Revoke pending invitations (per ADR-011). |
+| invites.read | invites | read | List and view invitations for the current organization (per ADR-011). |
+| auth.force_revoke | auth | force_revoke | Force-revoke a Person's Auth0 sessions and refresh-token families across all devices, immediately (per ADR-010 §3 and TASK-014J). Reserved for security incident response. |
 
 ### Seed role-permission matrix
 
@@ -259,6 +263,10 @@ Y = granted. Blank = not granted. Child roles inherit all parent grants (inherit
 | entity_types.delete | | | Y | | | | | | | | |
 | tenants.manage | | | Y | | | | | | | | |
 | system.configure | | | Y | | | | | | | | |
+| invites.send | Y | inh | inh | | | | | | | | |
+| invites.revoke | Y | inh | inh | | | | | | | | |
+| invites.read | Y | inh | inh | | | | | | | | |
+| auth.force_revoke | | | Y | | | | | | | | |
 
 Notes on the matrix:
 

--- a/specs/SPEC-007-api-contract-and-testing.md
+++ b/specs/SPEC-007-api-contract-and-testing.md
@@ -312,6 +312,12 @@ All paths are relative to `/api/v1/`. Every endpoint requires Auth0 JWT and `X-O
 |---|---|---|---|---|
 | GET | /auth/me | Person profile with all orgs and roles | authenticated | No |
 | GET | /auth/me/permissions | Effective permissions for current org | authenticated | Yes |
+| POST | /invitations | Create invitation (provider, admin, system_admin, cross_org) | invites.send | Yes |
+| GET | /invitations | List pending invitations for current org | invites.read | Yes |
+| GET | /invitations/{id} | View single invitation | invites.read | Yes |
+| POST | /invitations/{id}/resend | Re-issue email + rotate nonce | invites.send | Yes |
+| DELETE | /invitations/{id} | Revoke pending invitation | invites.revoke | Yes |
+| POST | /invitations/accept | Bind Person.auth_subject by nonce + JWT | authenticated | No |
 
 ### 8.2 EAV Platform (SPEC-001)
 
@@ -344,6 +350,7 @@ All paths are relative to `/api/v1/`. Every endpoint requires Auth0 JWT and `X-O
 | GET | /people/{id}/roles | List role assignments | roles.read |
 | POST | /people/{id}/roles | Assign role | roles.assign |
 | DELETE | /people/{id}/roles/{person_role_id} | Revoke role | roles.assign |
+| POST | /people/{id}/force-revoke | Force-revoke all Auth0 sessions + refresh-token families (security incident response, per TASK-014J) | auth.force_revoke |
 | GET | /roles | List roles | roles.read |
 | POST | /roles | Create custom role | roles.write |
 | PATCH | /roles/{id} | Update role | roles.write |
@@ -458,6 +465,7 @@ All paths are relative to `/api/v1/`. Every endpoint requires Auth0 JWT and `X-O
 |---|---|---|---|---|
 | GET | /health | Health check | none (public) | No |
 | GET | /health/ready | Readiness check (DB) | none (public) | No |
+| POST | /system/bootstrap | One-shot first-admin bootstrap (per TASK-014E); gated by deploy-time token file, not Auth0 JWT | deploy-token (file marker) | No |
 
 ---
 

--- a/tasks/TASK-014-auth-middleware.md
+++ b/tasks/TASK-014-auth-middleware.md
@@ -2,47 +2,72 @@
 
 **Status:** Not started
 **Spec sections:** SPEC-007 §3.1 (authentication flow), §3.2 (organization context); SPEC-002 §4 (auth subject rule, soft delete rule), §9
-**ADRs:** ADR-009
-**Depends on:** TASK-012, TASK-013
+**ADRs:** ADR-009 (layering), ADR-010 (consolidated auth architecture — must be Accepted before this task starts), ADR-012 (permission cache invalidation; this task adds the supporting column)
+**Depends on:** TASK-012, TASK-013, TASK-014A (ADR-010 must be ratified first)
 
 ## Objective
 
-Implement the three-layer auth middleware: JWT validation against Auth0 JWKS, person resolution from `auth_subject`, and organization context extraction from the `X-Organization-Id` header. This middleware runs on every request except health checks and `/auth/me`. It attaches the resolved identity and org context to the request for downstream permission checking.
+Implement the JWT validation middleware that runs on every authenticated request: validate against Auth0 JWKS, read `sub` and `org_id` claims (Auth0 Organizations per ADR-010), resolve `Person` by `auth_subject`, verify an active `PersonRole` exists in the requested org, set `SET LOCAL app.org_id` for RLS, and attach `current_person` + `current_org` to the request context.
+
+Bundles **one small schema migration**: add `Person.permissions_version INTEGER NOT NULL DEFAULT 0` per ADR-012. The column is used by TASK-015's cache and incremented by TASK-016/017/014J on every permission-affecting mutation.
+
+Routine login and logout are entirely Auth0-handled (TASK-014B configures the Auth0 side); the invitation flow that writes `Person.auth_subject` is TASK-014F/G; this task only validates already-issued tokens and enforces the per-request invariants.
+
+## Middleware check sequence (per design notes §5)
+
+Pulled out here so reviewers can audit one ordered list:
+
+1. **JWKS signature validation** against cached JWKS.
+2. **Required claims present.** Read `sub`, `org_id`, `is_active` (enriched by TASK-014C Post-Login Action). Reject if `org_id` is missing — org-tagless tokens are invalid post-Auth0-Orgs adoption.
+3. **`is_active` claim check.** Reject if false; fail-closed when missing.
+4. **Resolve `Person` by `auth_subject = sub`.** Reject if no match (401), or if the row is soft-deleted (`deleted_at IS NOT NULL`) or `is_active = false` (401). The `is_active` claim from step 3 is a fast path; the DB check is authoritative.
+5. **Active PersonRole in the JWT's `org_id`.** Query DB for an unrevoked `PersonRole(person_id, org_id)`. **Checked on every request, not derived from claims and not skipped on cache hit.**
+6. **`SET LOCAL app.org_id = <org_id>`** inside the request transaction so RLS policies key off the correct tenant.
+7. **Attach `current_person` and `current_org` to the request context** for downstream services.
 
 ## Acceptance Criteria
 
 - [ ] JWT extracted from `Authorization: Bearer {token}` header per SPEC-007 §3.1
 - [ ] JWT validated against Auth0 JWKS endpoint with in-process cache per SPEC-007 §3.1 step 2
-- [ ] `sub` claim extracted and matched to `Person.auth_subject` per SPEC-007 §3.1 step 3-4
-- [ ] No matching Person returns 401 (`unauthorized`)
-- [ ] `Person.is_active = false` returns 401 (`account_inactive`) per SPEC-007 §3.1 step 5
-- [ ] `Person.deleted_at IS NOT NULL` returns 401 (`account_inactive`) per SPEC-007 §3.1 step 5
-- [ ] `X-Organization-Id` required on all endpoints except `/auth/me` and `/health*` per SPEC-007 §3.2
-- [ ] Missing/invalid `X-Organization-Id` returns 400 (`organization_required`) per SPEC-007 §3.2
-- [ ] No active PersonRole in requested org returns 403 (`org_access_denied`) per SPEC-007 §3.1 step 8
-- [ ] Resolved person, org, and active roles attached to request context (FastAPI dependency)
-- [ ] `/health/ready` gains a real JWKS probe against the cache (reports healthy once the cache has loaded at least one key set). This is the first task that adds an `auth0_jwks` key to the readiness `checks` dict scaffolded in TASK-005
-- [ ] In the test environment, the auth middleware validates JWTs against the test-only public key produced by TASK-008's key fixture (via env vars or a fixed `tests/fixtures/jwt_keys/` path). All of TASK-008's token fixture negative-path cases (expired, wrong audience, missing sub) now produce real 401s through the live middleware
+- [ ] `sub`, `org_id`, and `is_active` claims read from validated token; missing `org_id` returns 401 (`organization_required`)
+- [ ] `Person` resolved by `auth_subject = sub`; no matching Person returns 401 (`unauthorized`)
+- [ ] `Person.is_active = false` returns 401 (`account_inactive`)
+- [ ] `Person.deleted_at IS NOT NULL` returns 401 (`account_inactive`)
+- [ ] Active `PersonRole` query in the JWT's `org_id` returns 403 (`org_access_denied`) if no row found; **this check runs on every request**, not derived from claims
+- [ ] `SET LOCAL app.org_id = <org_id>` issued at the start of the request transaction so RLS policies enforce tenant scope
+- [ ] `current_person` and `current_org` attached to the request context (FastAPI dependency)
+- [ ] **`Person.permissions_version INTEGER NOT NULL DEFAULT 0` column added via Alembic migration** per ADR-012
+- [ ] `/health/ready` gains a real JWKS probe against the cache (first task to add `auth0_jwks` to the readiness `checks` dict scaffolded in TASK-005)
+- [ ] In the test environment, the auth middleware validates JWTs against the test-only public key produced by TASK-008's key fixture. All of TASK-008's negative-path token fixtures (expired, wrong audience, missing `sub`, missing `org_id`) produce real 401s through the live middleware
 - [ ] The 008A auth stubs (`current_person`, `current_org`, `require_permission`) are flipped off by setting `AUTH_STUB_ENABLED=False` in the production path; tests may still opt into stub mode via a dedicated fixture where appropriate
-- [ ] `/auth/me` exempted from org header requirement per SPEC-007 §3.2
+- [ ] `/auth/me` exempted from `org_id` claim requirement per SPEC-007 §3.2
 - [ ] Health endpoints exempted from all auth per SPEC-007 §8.8
+- [ ] `X-Organization-Id` header is **no longer required**; `org_id` is read from the JWT claim. If the header is sent and disagrees with the JWT's `org_id`, return 400 (`organization_mismatch`).
 - [ ] Tests from SPEC-002 §11: `test_person_without_auth_subject_cannot_authenticate`, `test_inactive_person_returns_401`, `test_person_role_cross_tenant_returns_403`
-- [ ] **Deferred from TASK-012:** `test_soft_deleted_person_returns_401` (SPEC-002 §11, "soft delete rule" / §4 auth subject rule). TASK-012 listed this in its AC but could not implement it because the 401 path is owned by this middleware. Add it here alongside `test_inactive_person_returns_401` — same shape, different precondition (`Person.deleted_at IS NOT NULL`).
+- [ ] **Deferred from TASK-012:** `test_soft_deleted_person_returns_401` — same shape as `test_inactive_person_returns_401`, different precondition (`Person.deleted_at IS NOT NULL`)
 - [ ] Test: missing JWT returns 401
 - [ ] Test: expired JWT returns 401
-- [ ] Test: missing X-Organization-Id returns 400
+- [ ] Test: JWT missing `org_id` claim returns 401
+- [ ] Test: `X-Organization-Id` header disagreeing with JWT `org_id` returns 400
 
 ## Files
 
-- `backend/app/middleware/auth.py` (JWT validation, person resolution)
-- `backend/app/middleware/organization.py` (org context extraction)
+- `backend/app/middleware/auth.py` (JWT validation, person resolution, RLS context setting)
 - `backend/app/core/security.py` (JWKS cache, JWT decode)
-- `backend/app/core/dependencies.py` (FastAPI dependencies for current_person, current_org)
+- `backend/app/core/dependencies.py` (FastAPI dependencies for `current_person`, `current_org`)
 - `backend/app/main.py` (middleware registration)
+- `backend/app/models/identity.py` (`Person.permissions_version` column)
+- `backend/alembic/versions/{ts}_person_permissions_version.py` (migration)
 - `backend/tests/test_auth/test_jwt_validation.py`
 - `backend/tests/test_auth/test_org_context.py`
 
 ## Non-goals
 
-- Permission checking (TASK-015)
+- Permission resolution mechanics and caching (TASK-015 + TASK-014I)
 - Role hierarchy resolution (TASK-015)
+- Invitation flow (TASK-014F, TASK-014G)
+- Bootstrap (TASK-014E)
+- Post-Login Actions / app_metadata sync (TASK-014C)
+- Auth0 Management API client (TASK-014D)
+- Force-kill endpoint (TASK-014J)
+- Routine logout (Auth0 + SPA SDK; see TASK-014B)

--- a/tasks/TASK-014A-auth-consolidated-adr.md
+++ b/tasks/TASK-014A-auth-consolidated-adr.md
@@ -1,0 +1,33 @@
+# TASK-014A: Consolidated Auth0 Architecture ADR & Spec Edits
+
+**Status:** Not started
+**Spec sections:** SPEC-007 §3 (authentication and organization context)
+**ADRs:** ADR-010 (the ADR this task ratifies), ADR-008 (superseded)
+**Depends on:** (none — first link in the new auth chain)
+
+## Objective
+
+Ratify ADR-010 (consolidated Auth0 identity architecture) from Proposed to Accepted, mark ADR-008 as Superseded, and propagate the JWT-shape and binding-flow decisions into SPEC-007 §3 so every downstream task composes against a stable contract. This is a documentation-only task with no application code, but it is foundational — TASK-014 itself must not write any JWT-handling code until A is accepted, or the middleware will be built against an undecided contract.
+
+## Acceptance Criteria
+
+- [ ] ADR-010 status changes from `Proposed` to `Accepted`
+- [ ] ADR-008 status changes to `Superseded by ADR-010`
+- [ ] SPEC-007 §3.1 references Auth0 Organizations (`org_id` claim on every JWT) and the binding-by-nonce model
+- [ ] SPEC-007 §3.2 reflects org-switch as a fresh login (not a mid-session `X-Organization-Id` header swap)
+- [ ] SPEC-007 §3 cross-references ADR-010, ADR-011, and ADR-012 in the section header
+- [ ] STATE.md updated to note ADR-010 ratification and the start of the TASK-014 chain decomposition
+- [ ] No code changes — this task is doc-only
+
+## Files
+
+- `adrs/ADR-010-consolidated-auth-architecture.md` (status change)
+- `adrs/ADR-008-request-context-and-auth-provider-org-boundary.md` (status change)
+- `specs/SPEC-007-api-contract-and-testing.md` (§3 edits)
+- `STATE.md` (bookkeeping)
+
+## Non-goals
+
+- Any Auth0 tenant configuration work (TASK-014B)
+- Any middleware code (TASK-014)
+- Any Auth0 Management API integration (TASK-014D)

--- a/tasks/TASK-014B-auth0-tenant-configuration.md
+++ b/tasks/TASK-014B-auth0-tenant-configuration.md
@@ -1,0 +1,38 @@
+# TASK-014B: Auth0 Tenant Configuration & Environment Doc
+
+**Status:** Not started
+**Spec sections:** SPEC-007 §3.1 (JWT validation), §3.2 (org context)
+**ADRs:** ADR-010 (decisions this task implements on the Auth0 side)
+**Depends on:** TASK-014A
+
+## Objective
+
+Configure the Auth0 tenant per ADR-010: Organizations enabled, Universal Login with WebAuthn-first universal MFA, refresh token rotation with reuse/breach detection, single-connection-per-user (email/password + WebAuthn passkey), branded login pages, and per-environment callback/logout URLs. Produce an operational runbook plus a Terraform or CLI script that captures the configuration so dev/staging/prod tenants can be reproducibly provisioned. Routine login and logout become fully Auth0-handled by the end of this task — the backend has no role in routine logout flow.
+
+## Acceptance Criteria
+
+- [ ] Auth0 tenant has Organizations feature enabled
+- [ ] Universal Login configured with WebAuthn-first MFA policy; TOTP and SMS available as fallback factors
+- [ ] MFA enforcement is universal (no opt-out tier)
+- [ ] Refresh token rotation enabled with reuse/breach detection per ADR-010
+- [ ] Access token TTL set to 5–15 minutes per ADR-010
+- [ ] Single email/password + WebAuthn passkey connection configured; no social/SAML connections enabled in MVP
+- [ ] Per-environment callback URLs configured (dev, staging, prod)
+- [ ] `backend/app/core/config.py` settings extended: `auth0_domain`, `auth0_audience`, `auth0_issuer` (existing); plus `auth0_management_client_id`, `auth0_management_client_secret`, `auth0_management_audience` for TASK-014D
+- [ ] `.env.backend.example` updated with the new Auth0 env vars (no real secrets)
+- [ ] Operational runbook in `docs/auth0-tenant-setup.md` documents the Auth0 dashboard steps and any Terraform/CLI invocations
+- [ ] Test: `/health/ready` JWKS probe (already scaffolded in TASK-005) reports healthy against the configured tenant
+- [ ] Doc clarifies that routine login and logout are entirely Auth0-handled; backend has no logout endpoint
+
+## Files
+
+- `docs/auth0-tenant-setup.md` (new — operational runbook)
+- `backend/app/core/config.py` (extend settings)
+- `.env.backend.example` (new env vars)
+- (Optional) `infra/auth0/main.tf` if Terraform is chosen over manual dashboard config
+
+## Non-goals
+
+- Post-Login Action code (TASK-014C)
+- Management API integration code (TASK-014D)
+- Any JWT validation middleware (TASK-014 main)

--- a/tasks/TASK-014C-post-login-actions.md
+++ b/tasks/TASK-014C-post-login-actions.md
@@ -1,0 +1,36 @@
+# TASK-014C: Auth0 Post-Login Actions & Inactive-Person Sync
+
+**Status:** Not started
+**Spec sections:** SPEC-002 §4 (auth subject rule, soft delete rule), SPEC-007 §3.1
+**ADRs:** ADR-010 §2 (MFA), §3 (TTL), §6 (Person.is_active surface)
+**Depends on:** TASK-014B
+
+## Objective
+
+Implement the Auth0 Post-Login Action chain that enforces email-verification, universal MFA, and the inactive-Person gate before a JWT is issued. The inactive-Person gate must **not** call the backend synchronously per login — instead, `Person.is_active` is mirrored to Auth0 `app_metadata.is_active` via an event-driven backend webhook on every Person state change, and the Action reads the cached claim. Documents and enforces a fail-open vs fail-closed contract per Action; all three Actions in this task are fail-closed.
+
+## Acceptance Criteria
+
+- [ ] Auth0 Post-Login Action: **email verified gate** — rejects login if `email_verified === false`; fail-closed (no token issued)
+- [ ] Auth0 Post-Login Action: **MFA enforcement** — rejects login if MFA has not been completed for the current session; fail-closed; WebAuthn preferred per ADR-010 §2
+- [ ] Auth0 Post-Login Action: **inactive-Person gate** — rejects login if `app_metadata.is_active === false`; fail-closed when the claim is missing (treat as inactive)
+- [ ] Auth0 Post-Login Action: **claim enrichment** — bakes `org_id`, `is_active` into the issued JWT for use by the backend middleware
+- [ ] Backend webhook endpoint mirrors `Person.is_active` to `app_metadata.is_active` on every Person state change (activation, deactivation, soft-delete). Implemented as a service-method side effect, not a separate scheduler.
+- [ ] Webhook failures (Auth0 Management API unreachable) are retried with exponential backoff; permanent failure raises a `GroundworkError` so the Person state change rolls back rather than leaving Auth0 stale
+- [ ] Documented failure-mode contract for each Action (fail-open vs fail-closed) in `docs/auth0-post-login-actions.md`
+- [ ] Propagation-staleness window documented in the same doc: 15-minute worst-case for `is_active` deactivation; immediate revocation uses TASK-014J force-kill
+- [ ] Test: a Person whose `is_active` is set to `false` cannot acquire a new JWT after the next refresh cycle; existing access tokens continue to work until expiry (up to 15 min)
+
+## Files
+
+- `auth0/post-login-action.js` (Auth0-side; versioned alongside backend)
+- `backend/app/services/identity_service.py` (mirror `is_active` on Person state change)
+- `backend/app/services/auth0_sync_service.py` (new — webhook to Auth0 Management API)
+- `docs/auth0-post-login-actions.md` (failure-mode contract, staleness window doc)
+- `backend/tests/test_auth/test_app_metadata_sync.py`
+
+## Non-goals
+
+- Management API client itself (TASK-014D)
+- Force-kill operator endpoint (TASK-014J)
+- Permission claim enrichment beyond `org_id` and `is_active`

--- a/tasks/TASK-014D-auth0-management-api.md
+++ b/tasks/TASK-014D-auth0-management-api.md
@@ -1,0 +1,34 @@
+# TASK-014D: Auth0 Management API Integration
+
+**Status:** Not started
+**Spec sections:** SPEC-007 §3 (auth flow)
+**ADRs:** ADR-010
+**Depends on:** TASK-014B
+
+## Objective
+
+Implement the backend's Auth0 Management API client: M2M credentials, token caching with refresh, retry/backoff for transient failures, and a typed wrapper around the operations downstream tasks need. Used by TASK-014C (`app_metadata.is_active` sync), TASK-014E (bootstrap user + Auth0 Org creation), TASK-014F (Auth0 organization invitation, Auth0 user creation, Org membership management), and TASK-014J (session/refresh-family revocation).
+
+## Acceptance Criteria
+
+- [ ] `backend/app/services/auth0_management_service.py` — class-per-aggregate `Auth0ManagementService` per ADR-009; constructor injects HTTP client and config
+- [ ] Management API token acquired via Client Credentials grant against the management audience configured in TASK-014B
+- [ ] Token cached in-process with TTL aligned to Auth0's token lifetime; refreshed automatically on expiry or 401 from API
+- [ ] Wrapped operations (each a service method): create user, get user, update `app_metadata`, delete sessions, revoke refresh tokens, create organization, add organization member, remove organization member, create organization invitation, revoke organization invitation
+- [ ] Retry with exponential backoff for 429 and 5xx; permanent failure raises a `GroundworkError` subclass (`Auth0ManagementError`)
+- [ ] All Management API operations write `AuditLog` entries when invoked by a state-changing service method (the calling service is responsible for the audit row; the Management API client itself is audit-agnostic)
+- [ ] Tests: mock the Auth0 HTTP layer; verify retry behavior, token refresh on 401, error propagation
+- [ ] No real Auth0 calls in tests (per SPEC-007 §13.4)
+
+## Files
+
+- `backend/app/services/auth0_management_service.py`
+- `backend/app/core/exceptions.py` (add `Auth0ManagementError`)
+- `backend/tests/test_auth/test_management_api.py`
+
+## Non-goals
+
+- The Post-Login Action sync webhook itself (TASK-014C consumes this client)
+- Bootstrap flow (TASK-014E consumes this client)
+- Invitation flow (TASK-014F consumes this client)
+- Force-kill endpoint (TASK-014J consumes this client)

--- a/tasks/TASK-014E-bootstrap-first-admin.md
+++ b/tasks/TASK-014E-bootstrap-first-admin.md
@@ -1,0 +1,39 @@
+# TASK-014E: Bootstrap First Admin
+
+**Status:** Not started
+**Spec sections:** SPEC-007 §3 (auth flow), SPEC-002 §8 (Person management)
+**ADRs:** ADR-008 Epic 4 (resolves the cold-start gap), ADR-010
+**Depends on:** TASK-014D
+
+## Objective
+
+One-shot operator endpoint that provisions the first `Organization`, first `Person`, first `PersonRole(system_admin)`, plus the corresponding Auth0 Organization, Auth0 user, and Auth0 Org membership. Gated by a deploy-time provisioning token file at a known path on disk (e.g., `/var/run/groundwork/bootstrap.token`); the endpoint reads the token from the file, validates it against the inbound header, and **deletes the file on success**. Subsequent calls return `410 Gone`. No env-var fallback — env vars persist and would allow re-bootstrap.
+
+The bootstrap transaction spans both the application DB and Auth0. The two sides must succeed together; failure leaves the marker file in place so the operator can retry without leaving a half-provisioned tenant.
+
+## Acceptance Criteria
+
+- [ ] `POST /api/v1/system/bootstrap` endpoint exists; unauthenticated (no Auth0 JWT required) but requires `X-Bootstrap-Token` header
+- [ ] Token validation reads from `BOOTSTRAP_TOKEN_PATH` env var (configurable; defaults to a known path); endpoint compares header value to file contents (constant-time)
+- [ ] Endpoint returns `404 Not Found` if the marker file does not exist (no info leakage about whether bootstrap has been done)
+- [ ] Endpoint returns `410 Gone` if the marker file exists but the inbound token does not match
+- [ ] Endpoint returns `409 Conflict` if any `Person` already exists (defensive — should be impossible if marker file is managed correctly)
+- [ ] On success: creates `Organization`, `Person`, `PersonRole(system_admin)`, Auth0 Organization, Auth0 user, and Auth0 Org membership — all in one transaction across both systems
+- [ ] On success: deletes the marker file before returning 201
+- [ ] On any failure (DB or Auth0 side): rolls back DB changes; if Auth0-side mutations occurred, they are reversed via Management API compensating calls; marker file is **not** deleted so the operator can retry
+- [ ] Response includes the bootstrapped Person's Auth0 user ID and the password-change ticket URL (the operator delivers this to the human admin out-of-band)
+- [ ] Writes `AuditLog` row with `action='system.bootstrap'`, `actor_person_id` = the newly-created Person (self-attributed)
+- [ ] Tests: `test_bootstrap_succeeds_when_marker_exists_and_no_persons`, `test_bootstrap_returns_404_when_marker_absent`, `test_bootstrap_returns_410_when_token_mismatch`, `test_bootstrap_returns_409_when_persons_exist`, `test_bootstrap_rolls_back_db_on_auth0_failure`
+
+## Files
+
+- `backend/app/routers/system.py` (new — bootstrap endpoint)
+- `backend/app/services/bootstrap_service.py` (new — orchestrates the two-side transaction)
+- `backend/app/core/config.py` (`bootstrap_token_path` setting)
+- `backend/tests/test_system/test_bootstrap.py`
+
+## Non-goals
+
+- Invitation flow (TASK-014F)
+- Routine admin creation post-bootstrap (use TASK-014F invitations)
+- Any UI for triggering bootstrap (operator uses curl/script with the token file)

--- a/tasks/TASK-014F-invitation-resource.md
+++ b/tasks/TASK-014F-invitation-resource.md
@@ -1,0 +1,48 @@
+# TASK-014F: Invitation Resource (Model, CRUD, State Machine)
+
+**Status:** Not started
+**Spec sections:** SPEC-002 §2 (PersonRole entity_instance rules), §4 (assignment integrity), SPEC-007 §8 (endpoint inventory)
+**ADRs:** ADR-002 (FK-only), ADR-003 (partial unique index pattern), ADR-009 (service/model layering), ADR-010, ADR-011
+**Depends on:** TASK-014D
+
+## Objective
+
+Introduce the `Invitation` table — the **one new table for the entire auth chain** — with full CRUD endpoints, state machine, audit hooks, and the four-type discriminator. Implements the send side of the invitation flow per ADR-011: validates the type-specific payload, creates the Invitation row in `pending` state with a generated nonce, calls Auth0 Management API (TASK-014D) to add organization membership if needed (type 4) and create the Auth0 Organization invitation, and returns the uniform response envelope that closes the cross-tenant email enumeration vector.
+
+`PersonRole` is **not** created in this task — the planned role lives on the Invitation row until the accept transaction in TASK-014G fires.
+
+## Acceptance Criteria
+
+- [ ] `Invitation` model added per ADR-011 schema: `id`, `organization_id`, `type` enum, `email`, `first_name`, `last_name`, `planned_role_slug`, `planned_entity_instance_id`, `planned_entity_instance_payload` (JSONB), `nonce`, `state` enum, `auth0_invitation_id`, `created_by_person_id`, timestamps (`created_at`, `accepted_at`, `expired_at`, `revoked_at`, `expires_at`)
+- [ ] Partial unique index `(organization_id, email) WHERE state = 'pending'` per ADR-003
+- [ ] `POST /api/v1/invitations` creates an invite; requires `invites.send` permission; discriminates on `type` field
+- [ ] Provider invites (type 1) require `planned_entity_instance_payload` or `planned_entity_instance_id`; admin and system_admin invites (types 2 and 3) reject either
+- [ ] System_admin invites (type 3) callable only by an existing `system_admin`
+- [ ] Cross-org invites (type 4) require an existing `Person` with `auth_subject` set; backend calls Auth0 Management API to add the existing Auth0 user as a member of the target Auth0 Organization **before** creating the Auth0 invitation
+- [ ] All invite types: backend calls Auth0 Management API to create the Auth0 organization invitation; stores the returned Auth0 invitation ID on the Invitation row
+- [ ] `GET /api/v1/invitations` lists invitations for the requesting org; filterable by state; requires `invites.read`
+- [ ] `GET /api/v1/invitations/{id}` retrieves single invitation; requires `invites.read`
+- [ ] `POST /api/v1/invitations/{id}/resend` rotates the nonce, revokes the previous Auth0 invitation, creates a new one, refreshes `expires_at`; requires `invites.send`; only valid on `state = 'pending'`
+- [ ] `DELETE /api/v1/invitations/{id}` sets `state = 'revoked'`, revokes the Auth0 invitation; requires `invites.revoke`; only valid on `state = 'pending'`
+- [ ] All state transitions write `AuditLog` rows
+- [ ] **Uniform response shape** per ADR-011: `POST /invitations` returns `{status: "pending", invitation_id: "<uuid>"}` regardless of whether the email maps to an existing Person, was newly provisioned, or is a cross-org reactivation
+- [ ] `organization_id` is stamped from request context, never accepted from request body
+- [ ] Tests: `test_create_provider_invite_succeeds`, `test_create_admin_invite_succeeds`, `test_create_system_admin_invite_requires_system_admin_permission`, `test_create_cross_org_invite_adds_auth0_org_membership`, `test_duplicate_pending_invite_same_email_returns_409`, `test_resend_rotates_nonce`, `test_revoke_invite_sets_revoked_state`, `test_uniform_response_shape_regardless_of_existing_person`, `test_organization_id_in_body_ignored`
+
+## Files
+
+- `backend/app/models/identity.py` (add `Invitation` model)
+- `backend/app/enums/identity.py` (add `InvitationType`, `InvitationState`)
+- `backend/app/schemas/identity.py` (add `InvitationCreate*`, `InvitationResponse`)
+- `backend/app/services/invitation_service.py` (new)
+- `backend/app/routers/invitations.py` (new)
+- `backend/alembic/versions/{ts}_invitation_table.py` (migration)
+- `backend/tests/test_invitations/test_create.py`
+- `backend/tests/test_invitations/test_resend_revoke.py`
+- `backend/tests/test_invitations/test_uniform_response.py`
+
+## Non-goals
+
+- The accept endpoint and binding logic (TASK-014G)
+- Seeding `invites.send`, `invites.revoke`, `invites.read` permissions in the catalog (TASK-016 follow-on migration)
+- Type 5 (bootstrap) — that lives in TASK-014E with a different auth model

--- a/tasks/TASK-014G-invitation-accept-binding.md
+++ b/tasks/TASK-014G-invitation-accept-binding.md
@@ -1,0 +1,39 @@
+# TASK-014G: Invitation Accept Endpoint & Nonce Binding
+
+**Status:** Not started
+**Spec sections:** SPEC-002 §2 (PersonRole entity_instance rules), §4 (auth subject rule, assignment integrity), SPEC-007 §3.1 (auth flow), §8 (endpoint inventory)
+**ADRs:** ADR-009, ADR-010 §4, ADR-011, ADR-012
+**Depends on:** TASK-014F
+
+## Objective
+
+Implement `POST /api/v1/invitations/accept`, the only path that writes `Person.auth_subject`. Takes `{nonce, jwt}`, resolves the `Invitation` by nonce, validates state and TTL, performs the type-specific identity binding inside one transaction, and transitions the invitation to `accepted`. **Nonce-only — no email lookup, ever.** Increments `Person.permissions_version` (ADR-012) as part of the same transaction so any cached permissions for the newly bound Person are correct on the next request.
+
+## Acceptance Criteria
+
+- [ ] `POST /api/v1/invitations/accept` endpoint accepts `{nonce: string, jwt: string}` body; does **not** require an `X-Organization-Id` header (the invitation row carries the org)
+- [ ] Endpoint validates the inbound JWT against Auth0 JWKS (same path as TASK-014 middleware); reads `sub` and `org_id` claims
+- [ ] Endpoint resolves the `Invitation` by `nonce`; returns `410 Gone` if not found, expired, revoked, or already accepted
+- [ ] Endpoint verifies `Invitation.organization_id == JWT.org_id`; returns `422` on mismatch
+- [ ] For types 1–3 (new Person): creates the `Person` row with `auth_subject = JWT.sub`, plus first_name/last_name from the Invitation
+- [ ] For type 1 (provider): also creates the `EntityInstance` from `planned_entity_instance_payload` (or validates the existing `planned_entity_instance_id` belongs to the same org)
+- [ ] For type 4 (cross-org existing Person): looks up the `Person` by `auth_subject = JWT.sub`; returns `409 Conflict` if no matching Person exists (the type-4 invite was created for a Person that does not actually have a Person row yet)
+- [ ] Creates `PersonRole(person_id, planned_role_slug, organization_id, planned_entity_instance_id)`
+- [ ] Increments `Person.permissions_version` in the same transaction (per ADR-012)
+- [ ] Transitions the `Invitation` to `accepted` with `accepted_at = now()`
+- [ ] Writes `AuditLog` row: `action='invitation.accepted'`, `actor_person_id = newly-bound Person`, snapshots of previous and next state
+- [ ] Entire flow is one transaction; any failure rolls back all DB changes; the Invitation stays `pending` and can be retried (until TTL)
+- [ ] **No email matching anywhere in this code path.** Code review must reject any `WHERE email = ?` SELECT in the accept service method.
+- [ ] Tests: `test_accept_with_valid_nonce_and_jwt_writes_auth_subject_and_person_role`, `test_accept_with_unknown_nonce_returns_410`, `test_accept_with_expired_nonce_returns_410`, `test_accept_with_revoked_nonce_returns_410`, `test_accept_with_already_accepted_nonce_returns_410`, `test_accept_provider_creates_entity_instance`, `test_accept_cross_org_existing_person_creates_only_person_role`, `test_accept_cross_org_unknown_auth_subject_returns_409`, `test_accept_org_id_mismatch_returns_422`, `test_accept_increments_permissions_version`, `test_accept_writes_audit_log`
+
+## Files
+
+- `backend/app/services/invitation_service.py` (extend with `accept_invitation` method)
+- `backend/app/routers/invitations.py` (add `accept` endpoint)
+- `backend/tests/test_invitations/test_accept.py`
+
+## Non-goals
+
+- The send/list/resend/revoke endpoints (TASK-014F)
+- Any email-based lookup or fallback (explicitly forbidden — see AC)
+- Direct `POST /people/{id}/roles` assignment (that's TASK-017)

--- a/tasks/TASK-014H-service-caller-identity-deferred.md
+++ b/tasks/TASK-014H-service-caller-identity-deferred.md
@@ -1,0 +1,45 @@
+# TASK-014H: Service Caller Identity — DEFERRED
+
+**Status:** Deferred (not in MVP)
+**Spec sections:** SPEC-002 §4, SPEC-006 §3, SPEC-007 §3.1
+**ADRs:** ADR-010 §6
+**Depends on:** (TBD when reactivated)
+
+## Status note
+
+This task is **deferred** per ADR-010 §6. MVP has no inbound machine-to-machine callers:
+
+- Webhook receivers (Stripe and similar, when they exist) authenticate by shared-secret signature, not JWT
+- Outbound integrations (insurance eligibility checks, appointment reminders) run *as* the Groundwork backend itself, not as separate authenticated clients
+- Scheduled work (consent expiry sweep per ADR-006) is invoked as an authenticated admin HTTP request; the human operator is the audit actor
+
+Introducing a `ServicePrincipal` abstraction now, before any real caller exists, would be speculative design.
+
+## When to reactivate
+
+Reactivate this task when the first real inbound M2M caller is proposed:
+
+- A separate analytics service querying our API on its own credentials
+- A partner integration that authenticates server-to-server (not via shared-secret webhook signature)
+- An internal microservice extracted from the monolith
+
+## Scope when reactivated
+
+The work is well-defined; it is additive to the existing schema:
+
+- [ ] `ServicePrincipal` table: `id`, `name`, `auth0_client_id`, `is_active`, timestamps
+- [ ] `ServicePrincipalPermission` table — direct permission grants (OAuth scope pattern, no role layer); columns `(service_principal_id, permission_slug, conditions)` with the same conditions JSONB as `RolePermission`
+- [ ] `AuditLog` migration: add `actor_type` enum (`'human' | 'service'`) and `actor_service_principal_id` nullable FK; existing rows default to `actor_type='human'`; check constraint that exactly one of `actor_person_id` / `actor_service_principal_id` is non-null (or both null for system-triggered events)
+- [ ] Middleware branch on JWT claim shape: tokens with `gty=client_credentials` and no user `sub` resolve to a `ServicePrincipal` by `auth0_client_id`
+- [ ] Permission resolution branch: service principals skip the role hierarchy walk and consult `ServicePrincipalPermission` directly
+- [ ] `/auth/me` returns 404 for service principal callers (per ADR-010 documented as human-only)
+- [ ] Admin endpoints (`POST /api/v1/service-principals`, list, revoke) gated by a new `service_principals.manage` permission held only by `system_admin`
+- [ ] Tests covering each branch
+
+## Reference
+
+The migration path is documented in detail in ADR-010 §6. Read that section before reactivating this task.
+
+## Non-goals
+
+(All deferred; reactivate when first inbound M2M caller is proposed.)

--- a/tasks/TASK-014I-permission-cache-invalidation.md
+++ b/tasks/TASK-014I-permission-cache-invalidation.md
@@ -1,0 +1,39 @@
+# TASK-014I: Permission Cache Invalidation Strategy
+
+**Status:** Not started
+**Spec sections:** SPEC-002 §5 (resolution model), SPEC-007 §3.3 (caching contract)
+**ADRs:** ADR-012 (the strategy this task documents and finalizes)
+**Depends on:** TASK-014 (provides the `Person.permissions_version` column), TASK-015 (provides the cache implementation surface)
+
+## Objective
+
+Land the permission cache invalidation strategy from ADR-012 across all the code that mutates effective permissions. The `Person.permissions_version` column itself is migrated by TASK-014; the cache implementation lives in TASK-015. This task ensures the cache key shape `(person_id, organization_id, permissions_version)` is enforced, the per-request version read is implemented, and the write discipline in TASK-016 / TASK-017 / TASK-014J is verified by tests.
+
+Most of this task is **documentation, tests, and review** — the increment logic ships inside the tasks that mutate permissions. This task's role is to make sure the strategy is coherent end-to-end and to be the named place where the cache-correctness invariants are checked.
+
+## Acceptance Criteria
+
+- [ ] `backend/app/services/auth_service.py` (from TASK-015): permission cache key is `(person_id, organization_id, permissions_version)`. Confirmed by code review and a test that fails if any component is removed.
+- [ ] Resolver loads the current `Person.permissions_version` via an indexed PK lookup on every cache-resolution call; result is included in the cache key.
+- [ ] 60-second TTL still applies as a memory ceiling; **not** as a staleness window. Documented in the code with the rationale from ADR-012.
+- [ ] Integration tests verify the zero-staleness property:
+  - [ ] `test_role_revocation_invalidates_cache_immediately` — assign a role, hit a permission-gated endpoint (200), revoke the role, hit again immediately (403). No sleep, no TTL wait.
+  - [ ] `test_role_permission_grant_invalidates_cache_for_all_holders` — Person A and Person B both hold role R; granting a new permission to R produces immediate effect for both.
+  - [ ] `test_hierarchy_change_invalidates_cache` — Role R inherits from parent P; changing P's grants reflects on R's holders immediately.
+  - [ ] `test_force_kill_invalidates_cache` — TASK-014J's force-kill flow increments `permissions_version`; verifies cached entries are unreachable.
+- [ ] Granularity-tradeoff documented in code comments: `permissions_version` is per-Person, not per-(Person, org); cross-org cache invalidation on single-org change is acknowledged and the escape hatch (move to per-(person, org) table) is noted.
+- [ ] LISTEN/NOTIFY rejection rationale referenced in the task; no LISTEN/NOTIFY code path exists.
+- [ ] Logout flow note: routine logout is fully handled by Auth0 + SPA SDK per TASK-014B. The force-kill path is TASK-014J. This task does **not** ship a backend logout endpoint.
+
+## Files
+
+- (No new files for this task itself; references TASK-014, TASK-015, TASK-016, TASK-017, TASK-014J implementations)
+- `backend/tests/test_auth/test_cache_invalidation.py` (new — integration tests above)
+
+## Non-goals
+
+- The cache implementation primitives (TASK-015 owns those)
+- The `Person.permissions_version` migration (TASK-014 owns it)
+- The increment write logic in role/permission/personrole mutations (TASK-016, TASK-017 own those)
+- Force-kill endpoint (TASK-014J)
+- Routine logout (Auth0 + SPA SDK; no backend code)

--- a/tasks/TASK-014J-force-revoke.md
+++ b/tasks/TASK-014J-force-revoke.md
@@ -1,0 +1,38 @@
+# TASK-014J: Force-Kill (Operator-Triggered Session/Refresh Revocation)
+
+**Status:** Not started
+**Spec sections:** SPEC-002 §4 (soft delete and revocation), SPEC-007 §8 (endpoint inventory)
+**ADRs:** ADR-009, ADR-010 §3, ADR-012
+**Depends on:** TASK-014C (provides the `app_metadata.is_active` mirroring webhook), TASK-014D (provides Management API client), TASK-014I (provides cache invalidation discipline)
+
+## Objective
+
+Administrative endpoint for security-incident response: revoke **all** Auth0 sessions and refresh token families for a specific Person across every device, immediately. Triggered manually by an operator with the new `auth.force_revoke` permission (`system_admin` only by default). Bypasses the routine 15-minute access-token TTL window when the situation demands it (clinician termination after a breach, suspected credential compromise, regulatory hold).
+
+This is the operational counterpart to TASK-014C's routine `app_metadata.is_active` mirroring: `is_active` propagation handles routine deactivation within the TTL window; this endpoint handles the "now, across all devices" path.
+
+## Acceptance Criteria
+
+- [ ] `POST /api/v1/people/{id}/force-revoke` endpoint exists; requires `auth.force_revoke` permission
+- [ ] Endpoint flow (in one transaction):
+  1. Call Auth0 Management API (via TASK-014D client) to revoke the target Person's sessions and refresh-token families for our application
+  2. Set `Person.is_active = false` (the Post-Login Action sync from TASK-014C will mirror to `app_metadata`)
+  3. Increment `Person.permissions_version` so any in-flight cached permissions are invalidated on next request (per ADR-012)
+  4. Write `AuditLog` row: `action='auth.force_revoke'`, `actor_person_id = operator`, `resource_type='Person'`, `resource_id = target Person's id`
+- [ ] If Auth0 Management API call fails: the transaction rolls back (no `is_active=false` write, no version bump, no audit row) and a `GroundworkError` propagates as 502 Bad Gateway
+- [ ] Endpoint returns 404 if the target Person does not exist
+- [ ] Endpoint returns 422 if the operator tries to force-revoke themselves (defensive — `system_admin` should not self-revoke through this path)
+- [ ] Endpoint returns 409 if the target Person is already `is_active=false` (idempotent semantics: surface the no-op explicitly rather than silently re-running)
+- [ ] Tests: `test_force_revoke_succeeds_for_active_person`, `test_force_revoke_rolls_back_on_auth0_failure`, `test_force_revoke_requires_permission`, `test_force_revoke_self_returns_422`, `test_force_revoke_already_inactive_returns_409`, `test_force_revoke_increments_permissions_version`, `test_force_revoke_writes_audit_log`
+
+## Files
+
+- `backend/app/services/identity_service.py` (add `force_revoke` method)
+- `backend/app/routers/identity.py` (add force-revoke endpoint)
+- `backend/tests/test_identity/test_force_revoke.py`
+
+## Non-goals
+
+- Routine logout (Auth0 + SPA SDK; see TASK-014B)
+- Routine deactivation via `PATCH /people/{id}` setting `is_active=false` (TASK-012; covered by `app_metadata` sync)
+- Bulk revocation (single Person only; multi-target would be a separate task if needed)

--- a/tasks/TASK-016-role-permission-management-api.md
+++ b/tasks/TASK-016-role-permission-management-api.md
@@ -2,7 +2,7 @@
 
 **Status:** Not started
 **Spec sections:** SPEC-002 §8 (Role and permission management)
-**ADRs:** ADR-002 (FK-only), ADR-003 (partial unique indexes for revocable RolePermission grants), ADR-009
+**ADRs:** ADR-002 (FK-only), ADR-003 (partial unique indexes for revocable RolePermission grants), ADR-009, ADR-012 (permissions_version write discipline)
 **Depends on:** TASK-013, TASK-015
 
 ## Objective
@@ -23,7 +23,10 @@ Implement the role and permission management API: CRUD for custom roles, permiss
 - [ ] Duplicate role slug in same org returns 409 (`conflict`)
 - [ ] Duplicate active grant returns 409 per partial unique index
 - [ ] All state-changing operations write AuditLog entries per BR-07
+- [ ] **Permissions cache write discipline (per ADR-012):** every `RolePermission` grant/revoke and every `Role` hierarchy update (parent_role_id change) increments `Person.permissions_version` for every Person currently holding the affected role (or any descendant role via the hierarchy walk), in the same transaction as the mutation. This is the write-side enforcement of the cache invalidation strategy.
+- [ ] **Follow-on seed catalog migration:** add four new system permissions to the catalog seeded by TASK-013 — `invites.send`, `invites.revoke`, `invites.read` (per ADR-011), and `auth.force_revoke` (per TASK-014J). Update SPEC-002 §3 grant matrix: invite permissions granted to `admin` and `system_admin`; `auth.force_revoke` granted to `system_admin` only.
 - [ ] Tests from SPEC-002 §11: `test_create_child_role_different_domain_returns_422`, `test_delete_system_role_returns_409`, `test_duplicate_role_slug_same_org_returns_409`, `test_duplicate_active_grant_returns_409`, `test_grant_permission_writes_audit_log`
+- [ ] Tests: `test_grant_permission_increments_permissions_version_for_all_holders`, `test_revoke_permission_increments_permissions_version_for_all_holders`, `test_role_hierarchy_change_increments_permissions_version_for_descendants`
 
 ## Files
 

--- a/tasks/TASK-017-person-role-assignment-api.md
+++ b/tasks/TASK-017-person-role-assignment-api.md
@@ -2,7 +2,7 @@
 
 **Status:** Not started
 **Spec sections:** SPEC-002 §2 (PersonRole entity_instance_id rules), §8 (Person role assignment)
-**ADRs:** ADR-002 (FK-only), ADR-003 (partial unique indexes for revocable PersonRole grants), ADR-009
+**ADRs:** ADR-002 (FK-only), ADR-003 (partial unique indexes for revocable PersonRole grants), ADR-009, ADR-011 (PersonRole-at-accept; this task owns the direct-assignment path), ADR-012 (permissions_version write discipline)
 **Depends on:** TASK-012, TASK-013, TASK-015
 
 ## Objective
@@ -22,8 +22,11 @@ Implement the person role assignment API: listing role history, assigning roles 
 - [ ] Duplicate active assignment returns 409 per partial unique index
 - [ ] Revoked rows are historical, do not conflict with new assignments
 - [ ] All operations write AuditLog entries per BR-07
+- [ ] **Permissions cache write discipline (per ADR-012):** every `PersonRole` insert (assignment) and every `PersonRole` update setting `revoked_at` (revocation) increments the affected `Person.permissions_version` in the same transaction. This task and TASK-014G (invitation accept) are the two paths that create `PersonRole` rows; both must enforce this discipline.
+- [ ] **Coexistence with the invitation-accept path (per ADR-011):** This task owns direct assignment via `POST /people/{id}/roles` — the path used by admins adding a role to an existing Person. The invitation-accept path in TASK-014G creates `PersonRole` rows as a side effect of binding a newly-invited Person. The two paths must produce identical `PersonRole` rows (same columns set, same audit shape) so downstream queries do not need to distinguish them.
 - [ ] Tests from SPEC-002 §11: `test_duplicate_active_role_returns_409`, `test_assign_provider_role_without_entity_instance_returns_422`, `test_assign_provider_role_with_client_instance_returns_422`, `test_assign_provider_role_with_wrong_org_instance_returns_422`, `test_assign_system_admin_without_entity_instance_succeeds`, `test_revoke_role_sets_revoked_at`, `test_assign_role_writes_audit_log`, `test_revoke_role_writes_audit_log`
 - [ ] Test: `test_assign_role_from_different_org_returns_422` — assigning a non-system role that belongs to a different org is rejected per SPEC-002 §4 (assignment integrity rule)
+- [ ] Tests: `test_assign_role_increments_permissions_version`, `test_revoke_role_increments_permissions_version`
 
 ## Files
 


### PR DESCRIPTION
## Summary

Decomposes the auth chain (TASK-014) into ten ordered sub-tasks and resolves the architectural decisions that were implicit in the original scope. All docs-only — no code changes. Lands on a dedicated branch and is ready for review before any of the implementing tasks (014A–J) are picked up.

## What's new

**Three new ADRs:**

- **ADR-010 — Consolidated Auth0 identity architecture.** Auth0 Organizations adopted (org-bound JWTs), universal WebAuthn-preferred MFA, 5–15 min access tokens + refresh rotation with breach detection, nonce-only first-login binding (no email lookup), single-connection-per-user for MVP, and explicit deferral of `ServicePrincipal` until a real inbound M2M caller exists. **Supersedes ADR-008.**
- **ADR-011 — Invitation lifecycle and PersonRole post-accept.** `Invitation` as a first-class resource with state machine, five-type discriminator (provider / admin / system_admin / cross_org / bootstrap), nonce single-use semantics, and uniform response shape to close the cross-tenant email-enumeration vector. `PersonRole` is created at accept, never at send.
- **ADR-012 — Permission cache invalidation via `Person.permissions_version`.** Generation-column approach: zero staleness for tracked mutations, 60s TTL as a memory ceiling only. LISTEN/NOTIFY rejected for PgBouncer-incompatibility in transaction-pooling mode.

**Ten new task files:**

- 014A — Consolidated ADR ratification and SPEC-007 §3 edits (docs-only; blocks 014)
- 014B — Auth0 tenant configuration (Organizations, MFA, RT rotation, single connection)
- 014C — Post-Login Actions and `app_metadata.is_active` mirroring webhook
- 014D — Auth0 Management API client (M2M, token caching, retry)
- 014E — Bootstrap first admin via one-shot deploy-token file marker
- 014F — Invitation resource (the one new table)
- 014G — Invitation accept endpoint and nonce-binding
- 014H — Service caller identity, **deferred** (migration path documented)
- 014I — Permission cache invalidation strategy
- 014J — Force-revoke operator endpoint (security incident response)

**TASK-014 rewritten** to scope to JWT validation + the `Person.permissions_version` migration. Reads `org_id` from JWT claim per Auth0 Orgs adoption; `X-Organization-Id` header is no longer required (and produces a 400 if it disagrees with the JWT).

**TASK-016 and TASK-017 updated** with the `permissions_version` write discipline (every grant/revoke/role change increments the affected Person's version in the same transaction). TASK-016 also picks up the follow-on seed catalog migration for the four new permissions.

**SPEC-002 §3** gains four permission rows (`invites.send`, `invites.revoke`, `invites.read`, `auth.force_revoke`) plus matching grant-matrix entries. **SPEC-007 §8.1** gains six invitation endpoints, §8.3 gains the force-revoke endpoint, §8.8 gains the bootstrap endpoint.

**STATE.md** records the architectural change and expands the Phase 3 task index.

## Net schema delta for the entire auth chain

- **+1 table:** `Invitation`
- **+1 column:** `Person.permissions_version` (INTEGER, NOT NULL DEFAULT 0)
- **+4 seed permissions:** `invites.send`, `invites.revoke`, `invites.read`, `auth.force_revoke`

Everything else is Auth0-side configuration or backend code.

## Commits (six, separable for review)

1. `013675d` docs(adrs): add ADR-010, ADR-011, ADR-012 for auth chain
2. `4a28d97` docs(tasks): add TASK-014A through TASK-014J for auth chain decomposition
3. `99038d9` docs(tasks): rewrite TASK-014 for Auth0 Organizations + permissions_version
4. `b3461d6` docs(tasks): TASK-016 and TASK-017 inherit permissions_version discipline
5. `593a3ae` docs(specs): SPEC-002 catalog + SPEC-007 endpoint inventory for auth chain
6. `5790ac6` docs(state): record auth chain decomposition on task-014-auth-decomposition